### PR TITLE
Lets stop bumping the version in the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ With Maven:
 <dependency>
   <groupId>com.expedia.www</groupId>
   <artifactId>graphql-kotlin</artifactId>
-  <version>0.0.12</version>
+  <version>${latestVersion}</version>
 </dependency>
 ```
 
 With Gradle:
 
 ```groovy
-compile(group: 'com.expedia.www', artifact: 'graphql-kotlin', version: '0.0.12')
+compile(group: 'com.expedia.www', artifact: 'graphql-kotlin', version: '${latestVersion}')
 ```
 
 ## Generating a schema

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.expedia.www</groupId>
     <artifactId>graphql-kotlin</artifactId>
-    <version>0.0.12-SNAPSHOT</version>
+    <version>DEVELOPMENT</version>
     <name>graphql-kotlin</name>
     <description>Code-only GraphQL schema generation for Kotlin</description>
     <url>https://github.com/ExpediaDotCom/graphql-kotlin</url>


### PR DESCRIPTION
Since we don't publish snapshots at the moment lets just use `DEVELOPMENT` and
stop bumping the version number for release until we get it automated.

This lets us just draft a release when we want to kick travis to upload to
maven central.