### PR TITLE
Optimize imports and detekt warnings

### DIFF
--- a/detekt_baseline.xml
+++ b/detekt_baseline.xml
@@ -1,17 +1,10 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
-  <Blacklist timestamp="1526422183633"></Blacklist>
   <Whitelist timestamp="1535123065325">
     <ID>ComplexMethod:SchemaGenerator.kt$SchemaGenerator$private fun function(fn: KFunction&lt;*&gt;, target: Any? = null): GraphQLFieldDefinition</ID>
     <ID>LargeClass:SchemaGenerator.kt$SchemaGenerator</ID>
     <ID>TooManyFunctions:SchemaGenerator.kt$SchemaGenerator</ID>
     <ID>UnsafeCallOnNullableType:SchemaGenerator.kt$SchemaGenerator$name!!</ID>
     <ID>UnsafeCallOnNullableType:SchemaGenerator.kt$SchemaGenerator$type.arguments.first().type!!</ID>
-    <ID>UnsafeCast:SchemaGenerator.kt$SchemaGenerator$graphQLTypeOf(fn.returnType) as GraphQLOutputType</ID>
-    <ID>UnsafeCast:SchemaGenerator.kt$SchemaGenerator$graphQLTypeOf(parameter.type, true) as GraphQLInputType</ID>
-    <ID>UnsafeCast:SchemaGenerator.kt$SchemaGenerator$graphQLTypeOf(prop.returnType) as GraphQLOutputType</ID>
-    <ID>UnsafeCast:SchemaGenerator.kt$SchemaGenerator$graphQLTypeOf(prop.returnType, true) as GraphQLInputType</ID>
-    <ID>UnsafeCast:SchemaGenerator.kt$SchemaGenerator$type.classifier as KClass&lt;*&gt;</ID>
-    <ID>UnsafeCast:SchemaGeneratorTest.kt$SchemaGeneratorTest$query.type as GraphQLObjectType</ID>
   </Whitelist>
 </SmellBaseline>

--- a/src/main/kotlin/com/expedia/graphql/annotations/GraphQLDirective.kt
+++ b/src/main/kotlin/com/expedia/graphql/annotations/GraphQLDirective.kt
@@ -1,11 +1,11 @@
 package com.expedia.graphql.annotations
 
 import graphql.introspection.Introspection.DirectiveLocation
-import graphql.introspection.Introspection.DirectiveLocation.QUERY
-import graphql.introspection.Introspection.DirectiveLocation.MUTATION
 import graphql.introspection.Introspection.DirectiveLocation.FIELD
 import graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINITION
+import graphql.introspection.Introspection.DirectiveLocation.MUTATION
 import graphql.introspection.Introspection.DirectiveLocation.OBJECT
+import graphql.introspection.Introspection.DirectiveLocation.QUERY
 
 /**
  * Meta annotation used to denote an annotation as a GraphQL directive.

--- a/src/main/kotlin/com/expedia/graphql/schema/SchemaGenerator.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/SchemaGenerator.kt
@@ -33,6 +33,7 @@ import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.valueParameters
 import kotlin.reflect.jvm.jvmErasure
 
+@Suppress("Detekt.UnsafeCast")
 internal class SchemaGenerator(
     private val queries: List<TopLevelObjectDef>,
     private val mutations: List<TopLevelObjectDef>,

--- a/src/main/kotlin/com/expedia/graphql/schema/schemaAnnotations.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/schemaAnnotations.kt
@@ -10,13 +10,10 @@ import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLInputType
 import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.KClass
-import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
-import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 import kotlin.reflect.full.declaredMemberFunctions
 import kotlin.reflect.full.findAnnotation
-import kotlin.reflect.full.memberProperties
 import com.expedia.graphql.annotations.GraphQLDirective as DirectiveAnnotation
 
 internal fun KAnnotatedElement.graphQLDescription(): String? {

--- a/src/main/kotlin/com/expedia/graphql/toSchema.kt
+++ b/src/main/kotlin/com/expedia/graphql/toSchema.kt
@@ -1,7 +1,7 @@
 package com.expedia.graphql
 
-import com.expedia.graphql.schema.SchemaGeneratorConfig
 import com.expedia.graphql.schema.SchemaGenerator
+import com.expedia.graphql.schema.SchemaGeneratorConfig
 import graphql.schema.GraphQLSchema
 
 /**

--- a/src/test/kotlin/com/expedia/graphql/schema/SchemaGeneratorTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/SchemaGeneratorTest.kt
@@ -155,6 +155,7 @@ class SchemaGeneratorTest {
         assertEquals("thingthingthing", data["query"]?.get("repeat"))
     }
 
+    @Suppress("Detekt.UnsafeCast")
     @Test
     fun `SchemaGenerator ignores private fields`() {
         val schema =


### PR DESCRIPTION
Clean up the last detekt warnings. My next PR will actually fix the remaining base line ignores and delete the `detekt_baseline` file