### PR TITLE
refactor: move files before splitting up generator

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/schema/SchemaGeneratorConfig.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/SchemaGeneratorConfig.kt
@@ -1,5 +1,6 @@
 package com.expedia.graphql.schema
 
+import com.expedia.graphql.schema.generator.completableFutureResolver
 import com.expedia.graphql.schema.hooks.NoopSchemaGeneratorHooks
 import com.expedia.graphql.schema.hooks.SchemaGeneratorHooks
 import kotlin.reflect.KType

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/annotationExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/annotationExtensions.kt
@@ -1,9 +1,11 @@
-package com.expedia.graphql.schema
+package com.expedia.graphql.schema.extensions
 
 import com.expedia.graphql.annotations.GraphQLContext
 import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.annotations.GraphQLIgnore
 import com.expedia.graphql.schema.exceptions.CouldNotGetNameOfAnnotationException
+import com.expedia.graphql.schema.generator.graphQLScalar
+import com.expedia.graphql.schema.generator.isNotBlackListed
 import com.google.common.base.CaseFormat
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLDirective

--- a/src/main/kotlin/com/expedia/graphql/schema/generator/SchemaGenerator.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/generator/SchemaGenerator.kt
@@ -1,9 +1,16 @@
-package com.expedia.graphql.schema
+package com.expedia.graphql.schema.generator
 
 import com.expedia.graphql.TopLevelObjectDef
+import com.expedia.graphql.schema.KotlinDataFetcher
+import com.expedia.graphql.schema.Parameter
+import com.expedia.graphql.schema.SchemaGeneratorConfig
 import com.expedia.graphql.schema.exceptions.ConflictingTypesException
 import com.expedia.graphql.schema.exceptions.CouldNotGetNameOfEnumException
 import com.expedia.graphql.schema.exceptions.TypeNotSupportedException
+import com.expedia.graphql.schema.extensions.directives
+import com.expedia.graphql.schema.extensions.getDeprecationReason
+import com.expedia.graphql.schema.extensions.graphQLDescription
+import com.expedia.graphql.schema.extensions.isGraphQLContext
 import com.expedia.graphql.schema.extensions.wrapInNonNull
 import com.expedia.graphql.schema.models.KGraphQLType
 import graphql.TypeResolutionEnvironment

--- a/src/main/kotlin/com/expedia/graphql/schema/generator/schemaFilters.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/generator/schemaFilters.kt
@@ -1,5 +1,6 @@
-package com.expedia.graphql.schema
+package com.expedia.graphql.schema.generator
 
+import com.expedia.graphql.schema.extensions.isGraphQLIgnored
 import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.KCallable
 import kotlin.reflect.KFunction
@@ -12,14 +13,13 @@ private val componentFunctionRegex = Regex("component([0-9]+)")
 private typealias CallableFilter = (KCallable<*>) -> Boolean
 private typealias AnnotatedElementFilter = (KAnnotatedElement) -> Boolean
 
-internal typealias PropertyFilter = (KProperty<*>) -> Boolean
-internal typealias FunctionFilter = (KFunction<*>) -> Boolean
+private val isPublic: CallableFilter = { it.visibility == KVisibility.PUBLIC }
+private val isNotGraphQLIgnored: AnnotatedElementFilter = { it.isGraphQLIgnored().not() }
+
+private typealias PropertyFilter = (KProperty<*>) -> Boolean
+private typealias FunctionFilter = (KFunction<*>) -> Boolean
 
 internal val isNotBlackListed: FunctionFilter = { (blackListFunctions.contains(it.name) || it.name.matches(componentFunctionRegex)).not() }
-
-private val isPublic: CallableFilter = { it.visibility == KVisibility.PUBLIC }
-
-private val isNotGraphQLIgnored: AnnotatedElementFilter = { it.isGraphQLIgnored().not() }
 
 internal val propertyFilters: List<PropertyFilter> = listOf(isPublic, isNotGraphQLIgnored)
 internal val functionFilters: List<FunctionFilter> = listOf(isPublic, isNotGraphQLIgnored, isNotBlackListed)

--- a/src/main/kotlin/com/expedia/graphql/schema/generator/typeMappers.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/generator/typeMappers.kt
@@ -1,4 +1,4 @@
-package com.expedia.graphql.schema
+package com.expedia.graphql.schema.generator
 
 import graphql.Scalars
 import graphql.schema.GraphQLType
@@ -26,7 +26,7 @@ internal fun getGraphQLClassName(klass: KClass<*>, inputClass: Boolean): String?
     return if (simpleName != null && inputClass) getInputClassName(simpleName) else simpleName
 }
 
-private fun getInputClassName(className: String?) = "${className}Input"
+private fun getInputClassName(className: String) = "${className}Input"
 
 internal val completableFutureResolver = { type: KType ->
     if (type.classifier == CompletableFuture::class) {

--- a/src/main/kotlin/com/expedia/graphql/toSchema.kt
+++ b/src/main/kotlin/com/expedia/graphql/toSchema.kt
@@ -1,8 +1,8 @@
 package com.expedia.graphql
 
-import com.expedia.graphql.schema.SchemaGenerator
 import com.expedia.graphql.schema.SchemaGeneratorConfig
 import com.expedia.graphql.schema.exceptions.InvalidSchemaException
+import com.expedia.graphql.schema.generator.SchemaGenerator
 import graphql.schema.GraphQLSchema
 
 /**

--- a/src/test/kotlin/com/expedia/graphql/schema/generator/SchemaGeneratorAsyncTests.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/generator/SchemaGeneratorAsyncTests.kt
@@ -1,6 +1,8 @@
-package com.expedia.graphql.schema
+package com.expedia.graphql.schema.generator
 
 import com.expedia.graphql.TopLevelObjectDef
+import com.expedia.graphql.schema.SchemaGeneratorConfig
+import com.expedia.graphql.schema.testSchemaConfig
 import com.expedia.graphql.toSchema
 import graphql.schema.GraphQLNonNull
 import io.reactivex.Maybe
@@ -20,7 +22,7 @@ class SchemaGeneratorAsyncTests {
         } ?: type
     }
     private val testSchemaConfigWithRxJavaMonads =
-        SchemaGeneratorConfig(supportedPackages = "com.expedia", monadResolver = rxJavaMonadResolver)
+            SchemaGeneratorConfig(supportedPackages = "com.expedia", monadResolver = rxJavaMonadResolver)
 
     @Test
     fun `SchemaGenerator strips type argument from CompletableFuture to support async servlet`() {

--- a/src/test/kotlin/com/expedia/graphql/schema/generator/SchemaGeneratorAsyncTests.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/generator/SchemaGeneratorAsyncTests.kt
@@ -22,7 +22,7 @@ class SchemaGeneratorAsyncTests {
         } ?: type
     }
     private val testSchemaConfigWithRxJavaMonads =
-            SchemaGeneratorConfig(supportedPackages = "com.expedia", monadResolver = rxJavaMonadResolver)
+        SchemaGeneratorConfig(supportedPackages = "com.expedia", monadResolver = rxJavaMonadResolver)
 
     @Test
     fun `SchemaGenerator strips type argument from CompletableFuture to support async servlet`() {

--- a/src/test/kotlin/com/expedia/graphql/schema/generator/SchemaGeneratorTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/generator/SchemaGeneratorTest.kt
@@ -1,4 +1,4 @@
-package com.expedia.graphql.schema
+package com.expedia.graphql.schema.generator
 
 import com.expedia.graphql.TopLevelObjectDef
 import com.expedia.graphql.annotations.GraphQLDescription
@@ -7,6 +7,7 @@ import com.expedia.graphql.annotations.GraphQLIgnore
 import com.expedia.graphql.schema.extensions.deepName
 import com.expedia.graphql.schema.exceptions.ConflictingTypesException
 import com.expedia.graphql.schema.exceptions.InvalidSchemaException
+import com.expedia.graphql.schema.testSchemaConfig
 import com.expedia.graphql.toSchema
 import graphql.GraphQL
 import graphql.introspection.Introspection.DirectiveLocation.FIELD
@@ -340,9 +341,9 @@ class SchemaGeneratorTest {
     @GraphQLDescription("A place")
     @Whatever
     data class Geography(
-        val id: Int?,
-        val type: GeoType,
-        val locations: List<Location>
+            val id: Int?,
+            val type: GeoType,
+            val locations: List<Location>
     ) {
         @DirectiveOnFunction
         fun somethingCool(): String = "Something cool"
@@ -357,21 +358,21 @@ class SchemaGeneratorTest {
 
     class QueryWithRepeatedTypes {
         fun query(): Result =
-            Result(
-                listOf(),
-                listOf(),
-                listOf(),
-                listOf(),
-                SomeObject("something")
-            )
+                Result(
+                        listOf(),
+                        listOf(),
+                        listOf(),
+                        listOf(),
+                        SomeObject("something")
+                )
     }
 
     data class Result(
-        val someIntValues: List<Int>,
-        val someBooleanValues: List<Boolean>,
-        val someObjectValues: List<SomeObject>,
-        val someOtherObjectValues: List<SomeOtherObject>,
-        val someObject: SomeObject?
+            val someIntValues: List<Int>,
+            val someBooleanValues: List<Boolean>,
+            val someObjectValues: List<SomeObject>,
+            val someOtherObjectValues: List<SomeOtherObject>,
+            val someObject: SomeObject?
     )
 
     data class SomeObject(val name: String)
@@ -379,26 +380,26 @@ class SchemaGeneratorTest {
 
     class QueryWithNullableAndNonNullTypes {
         fun query(): MixedNullityResult =
-            MixedNullityResult("hey", "ho")
+                MixedNullityResult("hey", "ho")
     }
 
     data class MixedNullityResult(val oneThing: String?, val theNextThing: String)
 
     class QueryWithInputObject {
         fun query(someObject: SomeObject): SomeObject =
-            SomeObject("someName")
+                SomeObject("someName")
     }
 
     class QueryWithInputEnum {
         fun query(someEnum: SomeEnum): SomeEnum =
-            SomeEnum.SomeValue
+                SomeEnum.SomeValue
     }
 
     enum class SomeEnum { SomeValue }
 
     class QueryWithDataThatContainsFunction {
         fun query(something: String): ResultWithFunction? =
-            ResultWithFunction(something)
+                ResultWithFunction(something)
     }
 
     class ResultWithFunction(private val something: String) {

--- a/src/test/kotlin/com/expedia/graphql/schema/generator/SchemaGeneratorTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/generator/SchemaGeneratorTest.kt
@@ -4,9 +4,9 @@ import com.expedia.graphql.TopLevelObjectDef
 import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.annotations.GraphQLDirective
 import com.expedia.graphql.annotations.GraphQLIgnore
-import com.expedia.graphql.schema.extensions.deepName
 import com.expedia.graphql.schema.exceptions.ConflictingTypesException
 import com.expedia.graphql.schema.exceptions.InvalidSchemaException
+import com.expedia.graphql.schema.extensions.deepName
 import com.expedia.graphql.schema.testSchemaConfig
 import com.expedia.graphql.toSchema
 import graphql.GraphQL
@@ -283,7 +283,7 @@ class SchemaGeneratorTest {
     annotation class RenamedDirective(val x: Boolean)
 
     class QueryWithUnion {
-        fun query(whichHand: String): BodyPart = when(whichHand) {
+        fun query(whichHand: String): BodyPart = when (whichHand) {
             "right" -> RightHand(12)
             else -> LeftHand("hello world")
         }
@@ -293,11 +293,11 @@ class SchemaGeneratorTest {
 
     data class LeftHand(
         val field: String
-    ): BodyPart
+    ) : BodyPart
 
     data class RightHand(
         val property: Int
-    ): BodyPart
+    ) : BodyPart
 
     class QueryObject {
         @GraphQLDescription("A GraphQL query method")
@@ -341,9 +341,9 @@ class SchemaGeneratorTest {
     @GraphQLDescription("A place")
     @Whatever
     data class Geography(
-            val id: Int?,
-            val type: GeoType,
-            val locations: List<Location>
+        val id: Int?,
+        val type: GeoType,
+        val locations: List<Location>
     ) {
         @DirectiveOnFunction
         fun somethingCool(): String = "Something cool"
@@ -358,21 +358,21 @@ class SchemaGeneratorTest {
 
     class QueryWithRepeatedTypes {
         fun query(): Result =
-                Result(
-                        listOf(),
-                        listOf(),
-                        listOf(),
-                        listOf(),
-                        SomeObject("something")
-                )
+            Result(
+                listOf(),
+                listOf(),
+                listOf(),
+                listOf(),
+                SomeObject("something")
+            )
     }
 
     data class Result(
-            val someIntValues: List<Int>,
-            val someBooleanValues: List<Boolean>,
-            val someObjectValues: List<SomeObject>,
-            val someOtherObjectValues: List<SomeOtherObject>,
-            val someObject: SomeObject?
+        val someIntValues: List<Int>,
+        val someBooleanValues: List<Boolean>,
+        val someObjectValues: List<SomeObject>,
+        val someOtherObjectValues: List<SomeOtherObject>,
+        val someObject: SomeObject?
     )
 
     data class SomeObject(val name: String)
@@ -380,26 +380,26 @@ class SchemaGeneratorTest {
 
     class QueryWithNullableAndNonNullTypes {
         fun query(): MixedNullityResult =
-                MixedNullityResult("hey", "ho")
+            MixedNullityResult("hey", "ho")
     }
 
     data class MixedNullityResult(val oneThing: String?, val theNextThing: String)
 
     class QueryWithInputObject {
         fun query(someObject: SomeObject): SomeObject =
-                SomeObject("someName")
+            SomeObject("someName")
     }
 
     class QueryWithInputEnum {
         fun query(someEnum: SomeEnum): SomeEnum =
-                SomeEnum.SomeValue
+            SomeEnum.SomeValue
     }
 
     enum class SomeEnum { SomeValue }
 
     class QueryWithDataThatContainsFunction {
         fun query(something: String): ResultWithFunction? =
-                ResultWithFunction(something)
+            ResultWithFunction(something)
     }
 
     class ResultWithFunction(private val something: String) {


### PR DESCRIPTION
The next PR I am working on is splitting up the SchemaGenerator into smaller chunks so it is easier to read and to test. Before I do that I am setting up the new package structure that I think works best. Since all the changes are to internal files this is a non-breaking change