### PR TITLE
Deploy needs to checkout a local branch

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -17,6 +17,7 @@ fi
 
 echo "travis tag is set -> updating pom.xml <version> attribute to $TRAVIS_TAG"
 ./mvnw --batch-mode release:update-versions -DdevelopmentVersion=$TRAVIS_TAG-SNAPSHOT
+git checkout -b release-$TRAVIS_TAG
 ./mvnw --batch-mode --settings .travis/settings.xml --no-snapshot-updates -Prelease -DskipTests=true -DreleaseVersion=$TRAVIS_TAG -DcheckModificationExcludeList=pom.xml release:prepare
 ./mvnw --batch-mode --settings .travis/settings.xml -Prelease clean deploy -DskipTests=true -B -U
 echo "successfully deployed the jars to nexus"


### PR DESCRIPTION
It looks like travis is checking things out in a headless branch mode when
building tags which is causing problems when the release plugin goes to fetch
the git symbolic ref.