### PR TITLE
Fix type mismatch with Arrays of primitives when exposed as arguments

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/schema/generator/SchemaGenerator.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/generator/SchemaGenerator.kt
@@ -41,6 +41,7 @@ import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.superclasses
 import kotlin.reflect.full.valueParameters
+import kotlin.reflect.jvm.javaType
 import kotlin.reflect.jvm.jvmErasure
 
 @Suppress("Detekt.UnsafeCast")
@@ -138,7 +139,7 @@ internal class SchemaGenerator(
                 throw IllegalArgumentException("argument name is null or blank, $it")
             } else {
                 // Kotlin 1.3 will support contracts, until then we need to force non-null
-                args[name!!] = Parameter(it.type.jvmErasure.java, it.annotations)
+                args[name!!] = Parameter(it.type.javaType as Class<*>, it.annotations)
             }
         }
 


### PR DESCRIPTION
Arrays of Kotlin primitive type were mapped as array Java of primitives instead of arrays of java wrapping type.
This issue caused a type mismatch when the function is invoked in the datafetcher.