### PR TITLE
refactor: move more functions out of SchemaGenerator

### DIFF
--- a/detekt_baseline.xml
+++ b/detekt_baseline.xml
@@ -2,14 +2,12 @@
 <SmellBaseline>
   <Blacklist timestamp="1538767296980"></Blacklist>
   <Whitelist timestamp="1538768092037">
-    <ID>FunctionMaxLength:SchemaGenerator.kt$SchemaGenerator$@Throws(InvalidInputFieldTypeException::class) private fun throwIfInterfaceIsNotAuthorized(parameter: KParameter)</ID>
     <ID>FunctionOnlyReturningConstant:DirectiveTests.kt$Geography$@DirectiveOnFunction fun somethingCool(): String</ID>
     <ID>LargeClass:SchemaGenerator.kt$SchemaGenerator</ID>
     <ID>MethodOverloading:SchemaGeneratorTest.kt$SchemaGeneratorTest</ID>
     <ID>SpreadOperator:annotationExtensions.kt$(*directiveInfo.locations)</ID>
     <ID>TooManyFunctions:SchemaGenerator.kt$SchemaGenerator</ID>
     <ID>UnsafeCallOnNullableType:SchemaGenerator.kt$SchemaGenerator$name!!</ID>
-    <ID>UnsafeCallOnNullableType:SchemaGenerator.kt$SchemaGenerator$type.arguments.first().type!!</ID>
     <ID>UnsafeCast:SchemaGeneratorAsyncTests.kt$SchemaGeneratorAsyncTests$schema.getObjectType("TopLevelQuery").getFieldDefinition("asynchronouslyDo").type as GraphQLNonNull</ID>
     <ID>UnsafeCast:SchemaGeneratorAsyncTests.kt$SchemaGeneratorAsyncTests$schema.getObjectType("TopLevelQuery").getFieldDefinition("asynchronouslyDoSingle").type as GraphQLNonNull</ID>
     <ID>UnsafeCast:SchemaGeneratorAsyncTests.kt$SchemaGeneratorAsyncTests$schema.getObjectType("TopLevelQuery").getFieldDefinition("maybe").type as GraphQLNonNull</ID>

--- a/src/main/kotlin/com/expedia/graphql/schema/exceptions/InvalidListTypeException.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/exceptions/InvalidListTypeException.kt
@@ -1,0 +1,9 @@
+package com.expedia.graphql.schema.exceptions
+
+import kotlin.reflect.KType
+
+/**
+ * Thrown on mapping an invalid list type
+ */
+class InvalidListTypeException(type: KType)
+    : RuntimeException("Could not get the type of the first argument for the list $type")

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/annotationExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/annotationExtensions.kt
@@ -1,6 +1,5 @@
 package com.expedia.graphql.schema.extensions
 
-import com.expedia.graphql.annotations.GraphQLContext
 import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.annotations.GraphQLIgnore
 import com.expedia.graphql.schema.exceptions.CouldNotGetNameOfAnnotationException
@@ -12,8 +11,6 @@ import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLInputType
 import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.KClass
-import kotlin.reflect.KParameter
-import kotlin.reflect.KType
 import kotlin.reflect.full.declaredMemberFunctions
 import kotlin.reflect.full.findAnnotation
 import com.expedia.graphql.annotations.GraphQLDirective as DirectiveAnnotation
@@ -49,8 +46,6 @@ private fun KAnnotatedElement.listOfDirectives(): List<String> {
     )
     return directiveNames.filterNotNull()
 }
-
-internal fun KType.graphQLDescription(): String? = (classifier as? KClass<*>)?.graphQLDescription()
 
 internal fun KAnnotatedElement.getDeprecationReason(): String? {
     val annotation = this.findAnnotation<Deprecated>() ?: return null
@@ -94,7 +89,5 @@ internal fun KAnnotatedElement.directives() =
         builder.build()
     }
 }
-
-internal fun KParameter.isGraphQLContext() = this.findAnnotation<GraphQLContext>() != null
 
 private fun String.normalizeDirectiveName() = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, this)

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/kClassExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/kClassExtensions.kt
@@ -14,3 +14,8 @@ internal fun KClass<*>.getValidProperties(hooks: SchemaGeneratorHooks) = this.de
 internal fun KClass<*>.getValidFunctions(hooks: SchemaGeneratorHooks) = this.declaredMemberFunctions
     .filter { hooks.isValidFunction(it) }
     .filter { func -> functionFilters.all { it.invoke(func) } }
+
+internal fun KClass<*>.canBeGraphQLInterface(): Boolean = this.java.isInterface
+
+internal fun KClass<*>.canBeGraphQLUnion(): Boolean =
+    this.canBeGraphQLInterface() && this.declaredMemberProperties.isEmpty() && this.declaredMemberFunctions.isEmpty()

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/kParameterExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/kParameterExtensions.kt
@@ -1,0 +1,14 @@
+package com.expedia.graphql.schema.extensions
+
+import com.expedia.graphql.annotations.GraphQLContext
+import com.expedia.graphql.schema.exceptions.InvalidInputFieldTypeException
+import kotlin.reflect.KParameter
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.jvm.jvmErasure
+
+@Throws(InvalidInputFieldTypeException::class)
+internal fun KParameter.throwIfUnathorizedInterface() {
+    if (this.type.jvmErasure.java.isInterface) throw InvalidInputFieldTypeException()
+}
+
+internal fun KParameter.isGraphQLContext() = this.findAnnotation<GraphQLContext>() != null

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/kTypeExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/kTypeExtensions.kt
@@ -1,0 +1,11 @@
+package com.expedia.graphql.schema.extensions
+
+import com.expedia.graphql.schema.exceptions.InvalidListTypeException
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+
+internal fun KType.graphQLDescription(): String? = (classifier as? KClass<*>)?.graphQLDescription()
+
+@Throws(InvalidListTypeException::class)
+internal fun KType.getTypeOfFirstArgument(): KType =
+    this.arguments.first().type ?: throw InvalidListTypeException(this)

--- a/src/main/kotlin/com/expedia/graphql/schema/generator/dataFetcherUtils.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/generator/dataFetcherUtils.kt
@@ -1,0 +1,17 @@
+package com.expedia.graphql.schema.generator
+
+import graphql.schema.DataFetcherFactory
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLNonNull
+import graphql.schema.GraphQLOutputType
+
+internal fun updatePropertyFieldBuilder(propertyType: GraphQLOutputType, fieldBuilder: GraphQLFieldDefinition.Builder, dataFetcherFactory: DataFetcherFactory<*>?): GraphQLFieldDefinition.Builder {
+    val updatedFieldBuilder = if (propertyType is GraphQLNonNull) {
+        val graphQLOutputType = propertyType.wrappedType as? GraphQLOutputType
+        if (graphQLOutputType != null) fieldBuilder.type(graphQLOutputType) else fieldBuilder
+    } else {
+        fieldBuilder
+    }
+
+    return updatedFieldBuilder.dataFetcherFactory(dataFetcherFactory)
+}


### PR DESCRIPTION
Next I can pull out the specific type generators and have only the main methods like `graphqlTypeOf()` exposed on `SchemaGenerator`