### PR TITLE
feat: base exception

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/schema/exceptions/ConflictingTypesException.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/exceptions/ConflictingTypesException.kt
@@ -8,4 +8,4 @@ import kotlin.reflect.KClass
  * in the GraphQLType so all names must be unique.
  */
 class ConflictingTypesException(kClass1: KClass<*>, kClass2: KClass<*>)
-    : RuntimeException("Conflicting class names in schema generation [$kClass1, $kClass2]")
+    : GraphQLKotlinException("Conflicting class names in schema generation [$kClass1, $kClass2]")

--- a/src/main/kotlin/com/expedia/graphql/schema/exceptions/CouldNotGetJvmNameOfKTypeException.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/exceptions/CouldNotGetJvmNameOfKTypeException.kt
@@ -6,4 +6,4 @@ import kotlin.reflect.KType
  * Thrown when trying to generate a class and cannot resolve the jvm erasure name.
  */
 class CouldNotGetJvmNameOfKTypeException(kType: KType?)
-    : RuntimeException("Could not get the name of the KClass $kType")
+    : GraphQLKotlinException("Could not get the name of the KClass $kType")

--- a/src/main/kotlin/com/expedia/graphql/schema/exceptions/CouldNotGetNameOfAnnotationException.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/exceptions/CouldNotGetNameOfAnnotationException.kt
@@ -6,4 +6,4 @@ import kotlin.reflect.KClass
  * Thrown when unable to get the annotaiton name of a KAnnotatedElement.
  */
 class CouldNotGetNameOfAnnotationException(kClass: KClass<*>)
-    : RuntimeException("Could not get name of annotation class $kClass")
+    : GraphQLKotlinException("Could not get name of annotation class $kClass")

--- a/src/main/kotlin/com/expedia/graphql/schema/exceptions/CouldNotGetNameOfEnumException.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/exceptions/CouldNotGetNameOfEnumException.kt
@@ -6,4 +6,4 @@ import kotlin.reflect.KClass
  * Thrown when trying to generate an enum class and cannot resolve the simple name.
  */
 class CouldNotGetNameOfEnumException(kclass: KClass<*>)
-    : RuntimeException("Could not get the enum name of the KClass $kclass")
+    : GraphQLKotlinException("Could not get the enum name of the KClass $kclass")

--- a/src/main/kotlin/com/expedia/graphql/schema/exceptions/GraphQLKotlinException.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/exceptions/GraphQLKotlinException.kt
@@ -1,0 +1,7 @@
+package com.expedia.graphql.schema.exceptions
+
+/**
+ * Base exception that all our library exceptions extend from.
+ */
+open class GraphQLKotlinException(message: String = "", throwable: Throwable? = null)
+    : RuntimeException(message, throwable)

--- a/src/main/kotlin/com/expedia/graphql/schema/exceptions/InvalidInputFieldTypeException.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/exceptions/InvalidInputFieldTypeException.kt
@@ -28,4 +28,4 @@ package com.expedia.graphql.schema.exceptions
  *
  * data class PartOfUnion( val property: Int) : UnionMarkup
  */
-class InvalidInputFieldTypeException : RuntimeException("Object field argument cannot be an interface or a union")
+class InvalidInputFieldTypeException : GraphQLKotlinException("Object field argument cannot be an interface or a union")

--- a/src/main/kotlin/com/expedia/graphql/schema/exceptions/InvalidListTypeException.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/exceptions/InvalidListTypeException.kt
@@ -6,4 +6,4 @@ import kotlin.reflect.KType
  * Thrown on mapping an invalid list type
  */
 class InvalidListTypeException(type: KType)
-    : RuntimeException("Could not get the type of the first argument for the list $type")
+    : GraphQLKotlinException("Could not get the type of the first argument for the list $type")

--- a/src/main/kotlin/com/expedia/graphql/schema/exceptions/InvalidSchemaException.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/exceptions/InvalidSchemaException.kt
@@ -3,4 +3,4 @@ package com.expedia.graphql.schema.exceptions
 /**
  * Exception thrown on schema creation if no queries and no mutations are specified.
  */
-class InvalidSchemaException : RuntimeException("Schema requires at least one query or mutation")
+class InvalidSchemaException : GraphQLKotlinException("Schema requires at least one query or mutation")

--- a/src/main/kotlin/com/expedia/graphql/schema/exceptions/NestingNonNullTypeException.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/exceptions/NestingNonNullTypeException.kt
@@ -7,4 +7,4 @@ import kotlin.reflect.KType
  * Throws on nesting a non-null graphql type twice.
  */
 class NestingNonNullTypeException(gType: GraphQLType, kType: KType)
-    : RuntimeException("Already non null, don't need to nest, $gType, $kType")
+    : GraphQLKotlinException("Already non null, don't need to nest, $gType, $kType")

--- a/src/main/kotlin/com/expedia/graphql/schema/exceptions/TypeNotSupportedException.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/exceptions/TypeNotSupportedException.kt
@@ -4,4 +4,4 @@ package com.expedia.graphql.schema.exceptions
  * Thrown when the generator does not have a type to map to in GraphQL or in the hooks.
  */
 class TypeNotSupportedException(typeName: String, packageList: List<String>)
-    : RuntimeException("Cannot convert $typeName since it is outside the supported packages $packageList")
+    : GraphQLKotlinException("Cannot convert $typeName since it is outside the supported packages $packageList")


### PR DESCRIPTION
Creating a base exception for the entire library makes stack traces more clear and easier for clients to catch any exception while still being specific