### PR TITLE
Additional SchemaGeneratorHook that allows modifying GraphQLTypes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 
     <properties>
         <reflections.version>0.9.11</reflections.version>
-        <kotlin.version>1.2.71</kotlin.version>
+        <kotlin.version>1.3.10</kotlin.version>
         <kotlin-ktlint.version>0.29.0</kotlin-ktlint.version>
         <kotlin-detekt.version>1.0.0.RC8</kotlin-detekt.version>
         <mockk.version>1.8.9.kotlin13</mockk.version>

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/annotationExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/annotationExtensions.kt
@@ -11,7 +11,6 @@ import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLInputType
 import kotlin.reflect.KAnnotatedElement
-import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotation
 import com.expedia.graphql.annotations.GraphQLDirective as DirectiveAnnotation
 
@@ -64,11 +63,10 @@ internal fun KAnnotatedElement.isGraphQLIgnored() = this.findAnnotation<GraphQLI
 internal fun KAnnotatedElement.isGraphQLID() = this.findAnnotation<GraphQLID>() != null
 
 private fun Annotation.getDirectiveInfo(): DirectiveInfo? {
-    val directiveAnnotation = this.annotationClass.annotations.find { it is DirectiveAnnotation } as? DirectiveAnnotation
-    return when {
-        directiveAnnotation != null -> DirectiveInfo(this.annotationClass.simpleName ?: "", directiveAnnotation)
-        else -> null
-    }
+    return this.annotationClass.annotations
+        .filterIsInstance(DirectiveAnnotation::class.java)
+        .map { DirectiveInfo(this, it) }
+        .firstOrNull()
 }
 
 internal fun KAnnotatedElement.directives(hooks: SchemaGeneratorHooks) =
@@ -79,21 +77,24 @@ internal fun KAnnotatedElement.directives(hooks: SchemaGeneratorHooks) =
 
 @Throws(CouldNotGetNameOfAnnotationException::class)
 private fun DirectiveInfo.getGraphQLDirective(hooks: SchemaGeneratorHooks): GraphQLDirective {
-    val kClass: KClass<out DirectiveAnnotation> = this.annotation.annotationClass
-    val builder = GraphQLDirective.newDirective()
-    val name: String = this.effectiveName ?: throw CouldNotGetNameOfAnnotationException(kClass)
+    val directiveClass = this.directive.annotationClass
+    val name: String = this.effectiveName ?: throw CouldNotGetNameOfAnnotationException(directiveClass)
 
     @Suppress("Detekt.SpreadOperator")
+    val builder = GraphQLDirective.newDirective()
+        .name(name.normalizeDirectiveName())
+        .validLocations(*this.directiveAnnotation.locations)
+        .description(this.directiveAnnotation.description)
 
-    builder.name(name.normalizeDirectiveName())
-        .validLocations(*this.annotation.locations)
-        .description(this.annotation.description)
+    directiveClass.getValidProperties(hooks).forEach { property ->
+        val propertyName = property.name
+        val value = property.call(this.directive)
 
-    kClass.getValidFunctions(hooks).forEach { kFunction ->
-        val propertyName = kFunction.name
-        val value = kFunction.call(kClass)
         @Suppress("Detekt.UnsafeCast")
-        val type = defaultGraphQLScalars(kFunction.returnType) as GraphQLInputType
+        var type: GraphQLInputType? = defaultGraphQLScalars(property.returnType) as? GraphQLInputType
+        if (type == null) {
+            type = hooks.willGenerateGraphQLType(property.returnType) as? GraphQLInputType
+        }
         val argument = GraphQLArgument.newArgument()
             .name(propertyName)
             .value(value)
@@ -107,10 +108,10 @@ private fun DirectiveInfo.getGraphQLDirective(hooks: SchemaGeneratorHooks): Grap
 
 private fun String.normalizeDirectiveName() = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, this)
 
-private data class DirectiveInfo(private val name: String, val annotation: DirectiveAnnotation) {
+private data class DirectiveInfo(val directive: Annotation, val directiveAnnotation: DirectiveAnnotation) {
     val effectiveName: String? = when {
-        annotation.name.isNotEmpty() -> annotation.name
-        name.isNotEmpty() -> name
+        directiveAnnotation.name.isNotEmpty() -> directiveAnnotation.name
+        directive.annotationClass.simpleName.isNullOrEmpty().not() -> directive.annotationClass.simpleName
         else -> null
     }
 }

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/annotationExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/annotationExtensions.kt
@@ -93,19 +93,15 @@ private fun DirectiveInfo.getGraphQLDirective(hooks: SchemaGeneratorHooks): Grap
         .validLocations(*this.directiveAnnotation.locations)
         .description(this.directiveAnnotation.description)
 
-    directiveClass.getValidProperties(hooks).forEach { property ->
-        val propertyName = property.name
-        val value = property.call(this.directive)
+    directiveClass.getValidProperties(hooks).forEach { prop ->
+        val propertyName = prop.name
+        val value = prop.call(this.directive)
 
-        @Suppress("Detekt.UnsafeCast")
-        var type: GraphQLInputType? = defaultGraphQLScalars(property.returnType) as? GraphQLInputType
-        if (type == null) {
-            type = hooks.willGenerateGraphQLType(property.returnType) as? GraphQLInputType
-        }
+        val type = defaultGraphQLScalars(prop.returnType) ?: hooks.willGenerateGraphQLType(prop.returnType)
         val argument = GraphQLArgument.newArgument()
             .name(propertyName)
             .value(value)
-            .type(type)
+            .type(type as? GraphQLInputType)
             .build()
         builder.argument(argument)
     }

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/annotationExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/annotationExtensions.kt
@@ -11,6 +11,7 @@ import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLInputType
 import kotlin.reflect.KAnnotatedElement
+import kotlin.reflect.KParameter
 import kotlin.reflect.full.findAnnotation
 import com.expedia.graphql.annotations.GraphQLDirective as DirectiveAnnotation
 
@@ -70,6 +71,12 @@ private fun Annotation.getDirectiveInfo(): DirectiveInfo? {
 }
 
 internal fun KAnnotatedElement.directives(hooks: SchemaGeneratorHooks) =
+    this.annotations.asSequence()
+        .mapNotNull { it.getDirectiveInfo() }
+        .map { it.getGraphQLDirective(hooks) }
+        .toList()
+
+internal fun KParameter.directives(hooks: SchemaGeneratorHooks) =
     this.annotations.asSequence()
         .mapNotNull { it.getDirectiveInfo() }
         .map { it.getGraphQLDirective(hooks) }

--- a/src/main/kotlin/com/expedia/graphql/schema/generator/SchemaGenerator.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/generator/SchemaGenerator.kt
@@ -56,7 +56,6 @@ internal class SchemaGenerator(
 
     private val state = SchemaGeneratorState(config.supportedPackages)
     private val subTypeMapper = SubTypeMapper(config.supportedPackages)
-    private val wiringContext = WiringContext()
 
     internal fun generate(): GraphQLSchema {
         val builder = generateWithReflection()
@@ -152,7 +151,7 @@ internal class SchemaGenerator(
         val monadType = config.hooks.willResolveMonad(fn.returnType)
         builder.type(graphQLTypeOf(monadType) as GraphQLOutputType)
         val graphQLType = builder.build()
-        return config.hooks.onRewireGraphQLType(monadType, graphQLType, wiringContext) as GraphQLFieldDefinition
+        return config.hooks.onRewireGraphQLType(monadType, graphQLType) as GraphQLFieldDefinition
     }
 
     private fun property(prop: KProperty<*>): GraphQLFieldDefinition {
@@ -175,7 +174,7 @@ internal class SchemaGenerator(
             fieldBuilder
         }.build()
 
-        return config.hooks.onRewireGraphQLType(prop.returnType, field, wiringContext) as GraphQLFieldDefinition
+        return config.hooks.onRewireGraphQLType(prop.returnType, field) as GraphQLFieldDefinition
     }
 
     private fun argument(parameter: KParameter): GraphQLArgument {
@@ -190,7 +189,7 @@ internal class SchemaGenerator(
             state.directives.add(it)
         }
 
-        return config.hooks.onRewireGraphQLType(parameter.type, builder.build(), wiringContext) as GraphQLArgument
+        return config.hooks.onRewireGraphQLType(parameter.type, builder.build()) as GraphQLArgument
     }
 
     private fun graphQLTypeOf(type: KType, inputType: Boolean = false, annotatedAsID: Boolean = false): GraphQLType {

--- a/src/main/kotlin/com/expedia/graphql/schema/generator/WiringContext.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/generator/WiringContext.kt
@@ -1,0 +1,9 @@
+package com.expedia.graphql.schema.generator
+
+/**
+ * Schema generation related information
+ */
+@Suppress("Detekt.EmptyClassBlock")
+class WiringContext internal constructor() {
+    // TODO Provide analogs to `SchemaDirectiveWiringEnvironment.java`, see ExpediaDotCom/graphql-kotlin/issues/60
+}

--- a/src/main/kotlin/com/expedia/graphql/schema/generator/WiringContext.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/generator/WiringContext.kt
@@ -1,9 +1,0 @@
-package com.expedia.graphql.schema.generator
-
-/**
- * Schema generation related information
- */
-@Suppress("Detekt.EmptyClassBlock")
-class WiringContext internal constructor() {
-    // TODO Provide analogs to `SchemaDirectiveWiringEnvironment.java`, see ExpediaDotCom/graphql-kotlin/issues/60
-}

--- a/src/main/kotlin/com/expedia/graphql/schema/generator/directive/DirectiveWiringHelper.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/generator/directive/DirectiveWiringHelper.kt
@@ -1,0 +1,90 @@
+package com.expedia.graphql.schema.generator.directive
+
+import graphql.Assert.assertNotNull
+import graphql.schema.GraphQLDirectiveContainer
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLInterfaceType
+import graphql.schema.GraphQLUnionType
+import graphql.schema.GraphQLScalarType
+import graphql.schema.GraphQLEnumType
+import graphql.schema.GraphQLEnumValueDefinition
+import graphql.schema.GraphQLArgument
+import graphql.schema.GraphQLInputObjectField
+import graphql.schema.GraphQLInputObjectType
+import graphql.schema.GraphQLDirective
+import graphql.schema.GraphQLType
+import graphql.schema.idl.SchemaDirectiveWiring
+import graphql.schema.idl.SchemaDirectiveWiringEnvironment
+import graphql.schema.idl.SchemaDirectiveWiringEnvironmentImpl
+import graphql.schema.idl.WiringFactory
+
+/**
+ * Based on
+ * https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/schema/idl/SchemaGeneratorDirectiveHelper.java
+ */
+class DirectiveWiringHelper(private val wiringFactory: WiringFactory, private val manualWiring: Map<String, SchemaDirectiveWiring> = mutableMapOf()) {
+
+    @Suppress("UNCHECKED_CAST", "Detekt.ComplexMethod")
+    fun onWire(generatedType: GraphQLType): GraphQLType {
+        if (generatedType !is GraphQLDirectiveContainer) return generatedType
+
+        return wireDirectives(generatedType, getDirectives(generatedType),
+            { outputElement, directive -> createWiringEnvironment(outputElement, directive) },
+            { wiring, environment ->
+                when (environment.element) {
+                    is GraphQLObjectType -> wiring.onObject(environment as SchemaDirectiveWiringEnvironment<GraphQLObjectType>)
+                    is GraphQLFieldDefinition -> wiring.onField(environment as SchemaDirectiveWiringEnvironment<GraphQLFieldDefinition>)
+                    is GraphQLInterfaceType -> wiring.onInterface(environment as SchemaDirectiveWiringEnvironment<GraphQLInterfaceType>)
+                    is GraphQLUnionType -> wiring.onUnion(environment as SchemaDirectiveWiringEnvironment<GraphQLUnionType>)
+                    is GraphQLScalarType -> wiring.onScalar(environment as SchemaDirectiveWiringEnvironment<GraphQLScalarType>)
+                    is GraphQLEnumType -> wiring.onEnum(environment as SchemaDirectiveWiringEnvironment<GraphQLEnumType>)
+                    is GraphQLEnumValueDefinition -> wiring.onEnumValue(environment as SchemaDirectiveWiringEnvironment<GraphQLEnumValueDefinition>)
+                    is GraphQLArgument -> wiring.onArgument(environment as SchemaDirectiveWiringEnvironment<GraphQLArgument>)
+                    is GraphQLInputObjectType -> wiring.onInputObjectType(environment as SchemaDirectiveWiringEnvironment<GraphQLInputObjectType>)
+                    is GraphQLInputObjectField -> wiring.onInputObjectField(environment as SchemaDirectiveWiringEnvironment<GraphQLInputObjectField>)
+                    else -> generatedType
+                }
+            }
+        )
+    }
+
+    private fun getDirectives(generatedType: GraphQLDirectiveContainer): MutableList<GraphQLDirective> {
+        // A function without directives may still be rewired if the arguments have directives
+        val directives = generatedType.directives
+        if (generatedType is GraphQLFieldDefinition) {
+            generatedType.arguments.forEach { directives.addAll(it.directives) }
+        }
+        return directives
+    }
+
+    private fun <T : GraphQLDirectiveContainer> createWiringEnvironment(element: T, directive: GraphQLDirective): SchemaDirectiveWiringEnvironment<T> =
+        SchemaDirectiveWiringEnvironmentImpl(element, directive, null, null, null)
+
+    private fun <T : GraphQLDirectiveContainer> wireDirectives(
+        element: T,
+        directives: List<GraphQLDirective>,
+        envBuilder: (T, GraphQLDirective) -> SchemaDirectiveWiringEnvironment<T>,
+        invoker: (SchemaDirectiveWiring, SchemaDirectiveWiringEnvironment<T>) -> T
+    ): T {
+        var outputObject = element
+        for (directive in directives) {
+            val env = envBuilder.invoke(outputObject, directive)
+            val directiveWiring = discoverWiringProvider(directive.name, env)
+            if (directiveWiring != null) {
+                val newElement = invoker.invoke(directiveWiring, env)
+                assertNotNull(newElement, "The SchemaDirectiveWiring MUST return a non null return value for element '" + element.name + "'")
+                outputObject = newElement
+            }
+        }
+        return outputObject
+    }
+
+    private fun <T : GraphQLDirectiveContainer> discoverWiringProvider(directiveName: String, env: SchemaDirectiveWiringEnvironment<T>): SchemaDirectiveWiring? {
+        return if (wiringFactory.providesSchemaDirectiveWiring(env)) {
+            wiringFactory.getSchemaDirectiveWiring(env)
+        } else {
+            manualWiring[directiveName]
+        }
+    }
+}

--- a/src/main/kotlin/com/expedia/graphql/schema/hooks/SchemaGeneratorHooks.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/hooks/SchemaGeneratorHooks.kt
@@ -1,5 +1,6 @@
 package com.expedia.graphql.schema.hooks
 
+import com.expedia.graphql.schema.generator.WiringContext
 import graphql.schema.DataFetcher
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLSchema
@@ -52,6 +53,12 @@ interface SchemaGeneratorHooks {
      */
     @Suppress("Detekt.FunctionOnlyReturningConstant")
     fun isValidFunction(function: KFunction<*>): Boolean = true
+
+    /**
+     * Called after `willGenerateGraphQLType` and before `didGenerateGraphQLType`.
+     * Enables you to change the wiring, e.g. directives to alter data fetchers.
+     */
+    fun onRewireGraphQLType(type: KType, generatedType: GraphQLType, context: WiringContext): GraphQLType = generatedType
 
     /**
      * Called after wrapping the type based on nullity but before adding the generated type to the schema

--- a/src/main/kotlin/com/expedia/graphql/schema/hooks/SchemaGeneratorHooks.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/hooks/SchemaGeneratorHooks.kt
@@ -1,6 +1,5 @@
 package com.expedia.graphql.schema.hooks
 
-import com.expedia.graphql.schema.generator.WiringContext
 import graphql.schema.DataFetcher
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLSchema
@@ -58,7 +57,7 @@ interface SchemaGeneratorHooks {
      * Called after `willGenerateGraphQLType` and before `didGenerateGraphQLType`.
      * Enables you to change the wiring, e.g. directives to alter data fetchers.
      */
-    fun onRewireGraphQLType(type: KType, generatedType: GraphQLType, context: WiringContext): GraphQLType = generatedType
+    fun onRewireGraphQLType(type: KType, generatedType: GraphQLType): GraphQLType = generatedType
 
     /**
      * Called after wrapping the type based on nullity but before adding the generated type to the schema

--- a/src/test/kotlin/com/expedia/graphql/schema/generator/DirectiveTests.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/generator/DirectiveTests.kt
@@ -4,6 +4,7 @@ import com.expedia.graphql.TopLevelObjectDef
 import com.expedia.graphql.annotations.GraphQLDirective
 import com.expedia.graphql.schema.testSchemaConfig
 import com.expedia.graphql.toSchema
+import graphql.Scalars
 import graphql.introspection.Introspection
 import graphql.schema.GraphQLInputObjectType
 import graphql.schema.GraphQLNonNull
@@ -67,7 +68,16 @@ class DirectiveTests {
         assertNotNull(geographyType?.getFieldDefinition("somethingCool")?.getDirective("directiveOnFunction"))
         assertNotNull((schema.getType("Location") as? GraphQLObjectType)?.getDirective("renamedDirective"))
         assertNotNull(schema.getDirective("whatever"))
-        assertNotNull(schema.getDirective("renamedDirective"))
+
+        val renamedDirective = assertNotNull(schema.getDirective("renamedDirective"))
+        assertEquals(55L, renamedDirective.arguments[0].value)
+        assertEquals("count", renamedDirective.arguments[0].name)
+        assertEquals(Scalars.GraphQLLong, renamedDirective.arguments[0].type)
+
+        assertEquals("strawberries", renamedDirective.arguments[1].value)
+        assertEquals("fruit", renamedDirective.arguments[1].name)
+        assertEquals(Scalars.GraphQLString, renamedDirective.arguments[1].type)
+
         val directiveOnFunction = schema.getDirective("directiveOnFunction")
         assertNotNull(directiveOnFunction)
         assertEquals(
@@ -84,7 +94,7 @@ annotation class Whatever
 annotation class DirectiveOnFunction
 
 @GraphQLDirective(name = "RenamedDirective")
-annotation class RenamedDirective(val x: Boolean)
+annotation class RenamedDirective(val count: Long, val fruit: String)
 
 @Whatever
 class Geography(
@@ -101,7 +111,7 @@ enum class GeoType {
     CITY, STATE
 }
 
-@RenamedDirective(x = false)
+@RenamedDirective(55L, "strawberries")
 data class Location(val lat: Double, val lon: Double)
 
 class QueryObject {


### PR DESCRIPTION
This enables rewiring based on directives (see #60) by offering general purpose hooks that allows us to rewire/modify generated graphqltypes.

The base example for directive based authentication, would work with this:
https://www.graphql-java.com/documentation/v11/sdl-directives/

With this hook available I can then use a helper class such as this can be used to wire up the directives:
https://gist.github.com/d4rken/7cb60a6a7b315d25766ff15884f9b99b

The new hook has a placeholder `WiringContext` which would need to get some functionality to allow for feature parity with graphql-java's [`SchemaDirectiveEnvironment`](https://github.com/graphql-java/graphql-java/blob/5eb2ab743bf7afc05e2243d3dc0bcf22a0384366/src/main/java/graphql/schema/idl/SchemaDirectiveWiringEnvironment.java)

I was a bit out of my depth there though and couldn't find a clean solution.

Theoretically we could just keep it empty until someone needs the functionality then provide it. As it's passed via "context" object this wouldn't lead to breaking changes. `WiringContext` is created inside the `SchemaGenerator` where it would have access to the necessary information it's just unclear in what form to provide it.

I think it comes down to how close we want to mirror graphql-java and it's `SchemaDirectiveWiringEnvironment`...

