### PR TITLE
feat: remove requirement for @property: prefix

### DIFF
--- a/example/src/main/kotlin/com.expedia.graphql.sample/model/Widget.kt
+++ b/example/src/main/kotlin/com.expedia.graphql.sample/model/Widget.kt
@@ -5,12 +5,12 @@ import com.expedia.graphql.annotations.GraphQLIgnore
 
 @GraphQLDescription("A useful widget")
 data class Widget(
-    @property:GraphQLDescription("The widget's value that can be null")
+    @GraphQLDescription("The widget's value that can be null")
     var value: Int? = null,
-    @property:Deprecated(message = "This field is deprecated", replaceWith = ReplaceWith("value"))
-    @property:GraphQLDescription("The widget's deprecated value that shouldn't be used")
+    @Deprecated(message = "This field is deprecated", replaceWith = ReplaceWith("value"))
+    @GraphQLDescription("The widget's deprecated value that shouldn't be used")
     val deprecatedValue: Int? = value,
-    @property:GraphQLIgnore
+    @GraphQLIgnore
     val ignoredField: String? = "ignored",
     private val hiddenField: String? = "hidden"
 ) {

--- a/example/src/main/kotlin/com.expedia.graphql.sample/query/ScalarQuery.kt
+++ b/example/src/main/kotlin/com.expedia.graphql.sample/query/ScalarQuery.kt
@@ -24,7 +24,7 @@ class ScalarMutation : Mutation {
 }
 
 data class Person(
-    @property:GraphQLID
+    @GraphQLID
     val id: Int,
 
     val name: String

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/annotationExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/annotationExtensions.kt
@@ -3,19 +3,18 @@ package com.expedia.graphql.schema.extensions
 import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.annotations.GraphQLID
 import com.expedia.graphql.annotations.GraphQLIgnore
-import java.lang.reflect.Field
 import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.full.findAnnotation
 
-internal fun KAnnotatedElement.graphQLDescription(): String? = this.findAnnotation<GraphQLDescription>()?.value
-
-internal fun Field.graphQLDescription(): String? = this.getAnnotation(GraphQLDescription::class.java)?.value
+internal fun KAnnotatedElement.getGraphQLDescription(): String? = this.findAnnotation<GraphQLDescription>()?.value
 
 internal fun KAnnotatedElement.getDeprecationReason(): String? = this.findAnnotation<Deprecated>()?.getReason()
 
-internal fun Field.getDeprecationReason(): String? = this.getDeclaredAnnotation(Deprecated::class.java)?.getReason()
+internal fun KAnnotatedElement.isGraphQLIgnored(): Boolean = this.findAnnotation<GraphQLIgnore>() != null
 
-private fun Deprecated.getReason(): String? {
+internal fun KAnnotatedElement.isGraphQLID(): Boolean = this.findAnnotation<GraphQLID>() != null
+
+internal fun Deprecated.getReason(): String? {
     val builder = StringBuilder()
     builder.append(this.message)
 
@@ -26,7 +25,3 @@ private fun Deprecated.getReason(): String? {
 
     return builder.toString()
 }
-
-internal fun KAnnotatedElement.isGraphQLIgnored() = this.findAnnotation<GraphQLIgnore>() != null
-
-internal fun KAnnotatedElement.isGraphQLID() = this.findAnnotation<GraphQLID>() != null

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/booleanExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/booleanExtensions.kt
@@ -1,0 +1,3 @@
+package com.expedia.graphql.schema.extensions
+
+internal fun Boolean?.isTrue(): Boolean = this == true

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/fieldExtenstions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/fieldExtenstions.kt
@@ -1,0 +1,8 @@
+package com.expedia.graphql.schema.extensions
+
+import com.expedia.graphql.annotations.GraphQLDescription
+import java.lang.reflect.Field
+
+internal fun Field.getGraphQLDescription(): String? = this.getAnnotation(GraphQLDescription::class.java)?.value
+
+internal fun Field.getDeprecationReason(): String? = this.getDeclaredAnnotation(Deprecated::class.java)?.getReason()

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/kClassExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/kClassExtensions.kt
@@ -22,10 +22,10 @@ internal fun KClass<*>.getValidFunctions(hooks: SchemaGeneratorHooks): List<KFun
         .filter { hooks.isValidFunction(it) }
         .filter { func -> functionFilters.all { it.invoke(func) } }
 
-internal fun KClass<*>.findConstructorParamter(kProperty: KProperty<*>): KParameter? =
+internal fun KClass<*>.findConstructorParamter(name: String): KParameter? =
     this.primaryConstructor
         ?.parameters
-        ?.find { it.isSameType(kProperty) }
+        ?.find { it.name == name }
 
 internal fun KClass<*>.isGraphQLInterface(): Boolean = this.java.isInterface
 

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/kClassExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/kClassExtensions.kt
@@ -4,17 +4,28 @@ import com.expedia.graphql.schema.generator.functionFilters
 import com.expedia.graphql.schema.generator.propertyFilters
 import com.expedia.graphql.schema.hooks.SchemaGeneratorHooks
 import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.KParameter
+import kotlin.reflect.KProperty
 import kotlin.reflect.full.declaredMemberFunctions
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.full.primaryConstructor
 
-internal fun KClass<*>.getValidProperties(hooks: SchemaGeneratorHooks) = this.declaredMemberProperties
-    .filter { hooks.isValidProperty(it) }
-    .filter { prop -> propertyFilters.all { it.invoke(prop) } }
+internal fun KClass<*>.getValidProperties(hooks: SchemaGeneratorHooks): List<KProperty<*>> =
+    this.declaredMemberProperties
+        .filter { hooks.isValidProperty(it) }
+        .filter { prop -> propertyFilters.all { it.invoke(prop, this) } }
 
-internal fun KClass<*>.getValidFunctions(hooks: SchemaGeneratorHooks) = this.declaredMemberFunctions
-    .filter { hooks.isValidFunction(it) }
-    .filter { func -> functionFilters.all { it.invoke(func) } }
+internal fun KClass<*>.getValidFunctions(hooks: SchemaGeneratorHooks): List<KFunction<*>> =
+    this.declaredMemberFunctions
+        .filter { hooks.isValidFunction(it) }
+        .filter { func -> functionFilters.all { it.invoke(func) } }
+
+internal fun KClass<*>.findConstructorParamter(kProperty: KProperty<*>): KParameter? =
+    this.primaryConstructor
+        ?.parameters
+        ?.find { it.isSameType(kProperty) }
 
 internal fun KClass<*>.isGraphQLInterface(): Boolean = this.java.isInterface
 

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/kParameterExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/kParameterExtensions.kt
@@ -3,6 +3,7 @@ package com.expedia.graphql.schema.extensions
 import com.expedia.graphql.annotations.GraphQLContext
 import com.expedia.graphql.schema.exceptions.InvalidInputFieldTypeException
 import kotlin.reflect.KParameter
+import kotlin.reflect.KProperty
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.jvm.jvmErasure
 
@@ -10,5 +11,8 @@ import kotlin.reflect.jvm.jvmErasure
 internal fun KParameter.throwIfUnathorizedInterface() {
     if (this.type.jvmErasure.java.isInterface) throw InvalidInputFieldTypeException()
 }
+
+internal fun KParameter.isSameType(kProperty: KProperty<*>): Boolean =
+    this.name == kProperty.name && this.type == kProperty.returnType
 
 internal fun KParameter.isGraphQLContext() = this.findAnnotation<GraphQLContext>() != null

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/kParameterExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/kParameterExtensions.kt
@@ -3,7 +3,6 @@ package com.expedia.graphql.schema.extensions
 import com.expedia.graphql.annotations.GraphQLContext
 import com.expedia.graphql.schema.exceptions.InvalidInputFieldTypeException
 import kotlin.reflect.KParameter
-import kotlin.reflect.KProperty
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.jvm.jvmErasure
 
@@ -11,8 +10,5 @@ import kotlin.reflect.jvm.jvmErasure
 internal fun KParameter.throwIfUnathorizedInterface() {
     if (this.type.jvmErasure.java.isInterface) throw InvalidInputFieldTypeException()
 }
-
-internal fun KParameter.isSameType(kProperty: KProperty<*>): Boolean =
-    this.name == kProperty.name && this.type == kProperty.returnType
 
 internal fun KParameter.isGraphQLContext() = this.findAnnotation<GraphQLContext>() != null

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/kPropertyExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/kPropertyExtensions.kt
@@ -5,7 +5,7 @@ import kotlin.reflect.KProperty
 
 internal fun KProperty<*>.isPropertyGraphQLID(parentClass: KClass<*>): Boolean = when {
     this.isGraphQLID() -> true
-    parentClass.findConstructorParamter(this)
+    parentClass.findConstructorParamter(this.name)
         ?.isGraphQLID()
         .isTrue() -> true
     else -> false
@@ -13,14 +13,14 @@ internal fun KProperty<*>.isPropertyGraphQLID(parentClass: KClass<*>): Boolean =
 
 internal fun KProperty<*>.isPropertyGraphQLIgnored(parentClass: KClass<*>): Boolean = when {
     this.isGraphQLIgnored() -> true
-    parentClass.findConstructorParamter(this)
+    parentClass.findConstructorParamter(this.name)
         ?.isGraphQLIgnored()
         .isTrue() -> true
     else -> false
 }
 
 internal fun KProperty<*>.getPropertyDeprecationReason(parentClass: KClass<*>): String? =
-    this.getDeprecationReason() ?: parentClass.findConstructorParamter(this)?.getDeprecationReason()
+    this.getDeprecationReason() ?: parentClass.findConstructorParamter(this.name)?.getDeprecationReason()
 
 internal fun KProperty<*>.getPropertyDescription(parentClass: KClass<*>): String? =
-    this.getGraphQLDescription() ?: parentClass.findConstructorParamter(this)?.getGraphQLDescription()
+    this.getGraphQLDescription() ?: parentClass.findConstructorParamter(this.name)?.getGraphQLDescription()

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/kPropertyExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/kPropertyExtensions.kt
@@ -1,0 +1,26 @@
+package com.expedia.graphql.schema.extensions
+
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+
+internal fun KProperty<*>.isPropertyGraphQLID(parentClass: KClass<*>): Boolean = when {
+    this.isGraphQLID() -> true
+    parentClass.findConstructorParamter(this)
+        ?.isGraphQLID()
+        .isTrue() -> true
+    else -> false
+}
+
+internal fun KProperty<*>.isPropertyGraphQLIgnored(parentClass: KClass<*>): Boolean = when {
+    this.isGraphQLIgnored() -> true
+    parentClass.findConstructorParamter(this)
+        ?.isGraphQLIgnored()
+        .isTrue() -> true
+    else -> false
+}
+
+internal fun KProperty<*>.getPropertyDeprecationReason(parentClass: KClass<*>): String? =
+    this.getDeprecationReason() ?: parentClass.findConstructorParamter(this)?.getDeprecationReason()
+
+internal fun KProperty<*>.getPropertyDescription(parentClass: KClass<*>): String? =
+    this.getGraphQLDescription() ?: parentClass.findConstructorParamter(this)?.getGraphQLDescription()

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/kTypeExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/kTypeExtensions.kt
@@ -6,8 +6,6 @@ import kotlin.reflect.KType
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.isSubclassOf
 
-internal fun KType.graphQLDescription(): String? = (classifier as? KClass<*>)?.graphQLDescription()
-
 @Throws(InvalidListTypeException::class)
 internal fun KType.getTypeOfFirstArgument(): KType =
     this.arguments.firstOrNull()?.type ?: throw InvalidListTypeException(this)

--- a/src/main/kotlin/com/expedia/graphql/schema/generator/SchemaGenerator.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/generator/SchemaGenerator.kt
@@ -95,8 +95,8 @@ internal class SchemaGenerator(
     internal fun function(fn: KFunction<*>, target: Any? = null, abstract: Boolean = false) =
         functionTypeBuilder.function(fn, target, abstract)
 
-    internal fun property(prop: KProperty<*>) =
-        propertyTypeBuilder.property(prop)
+    internal fun property(prop: KProperty<*>, parentClass: KClass<*>) =
+        propertyTypeBuilder.property(prop, parentClass)
 
     internal fun listType(type: KType, inputType: Boolean) =
         listTypeBuilder.listType(type, inputType)

--- a/src/main/kotlin/com/expedia/graphql/schema/generator/schemaFilters.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/generator/schemaFilters.kt
@@ -1,25 +1,29 @@
 package com.expedia.graphql.schema.generator
 
 import com.expedia.graphql.schema.extensions.isGraphQLIgnored
+import com.expedia.graphql.schema.extensions.isPropertyGraphQLIgnored
 import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.KCallable
+import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty
 import kotlin.reflect.KVisibility
 
 private typealias CallableFilter = (KCallable<*>) -> Boolean
 private typealias AnnotatedElementFilter = (KAnnotatedElement) -> Boolean
-private typealias PropertyFilter = (KProperty<*>) -> Boolean
+private typealias PropertyFilter = (KProperty<*>, KClass<*>) -> Boolean
 private typealias FunctionFilter = (KFunction<*>) -> Boolean
 
 private val blackListFunctions: List<String> = listOf("annotationType", "toString", "copy", "equals", "hashCode")
 private val componentFunctionRegex = Regex("component([0-9]+)")
 
 private val isPublic: CallableFilter = { it.visibility == KVisibility.PUBLIC }
+private val isPropertyPublic: PropertyFilter = { prop, _ -> isPublic(prop) }
 private val isNotGraphQLIgnored: AnnotatedElementFilter = { it.isGraphQLIgnored().not() }
+private val isPropertyNotGraphQLIgnored: PropertyFilter = { prop, parentClass -> prop.isPropertyGraphQLIgnored(parentClass).not() }
 private val isBlacklistedFunction: FunctionFilter = { blackListFunctions.contains(it.name) }
 private val isComponentFunction: FunctionFilter = { it.name.matches(componentFunctionRegex) }
 private val isNotBlackListed: FunctionFilter = { (isBlacklistedFunction(it) || isComponentFunction(it)).not() }
 
-internal val propertyFilters: List<PropertyFilter> = listOf(isPublic, isNotGraphQLIgnored)
+internal val propertyFilters: List<PropertyFilter> = listOf(isPropertyPublic, isPropertyNotGraphQLIgnored)
 internal val functionFilters: List<FunctionFilter> = listOf(isPublic, isNotGraphQLIgnored, isNotBlackListed)

--- a/src/main/kotlin/com/expedia/graphql/schema/generator/types/EnumTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/generator/types/EnumTypeBuilder.kt
@@ -1,7 +1,7 @@
 package com.expedia.graphql.schema.generator.types
 
 import com.expedia.graphql.schema.extensions.getDeprecationReason
-import com.expedia.graphql.schema.extensions.graphQLDescription
+import com.expedia.graphql.schema.extensions.getGraphQLDescription
 import com.expedia.graphql.schema.generator.SchemaGenerator
 import com.expedia.graphql.schema.generator.TypeBuilder
 import graphql.schema.GraphQLEnumType
@@ -13,7 +13,7 @@ internal class EnumTypeBuilder(generator: SchemaGenerator) : TypeBuilder(generat
         val enumBuilder = GraphQLEnumType.newEnum()
 
         enumBuilder.name(kClass.simpleName)
-        enumBuilder.description(kClass.graphQLDescription())
+        enumBuilder.description(kClass.getGraphQLDescription())
 
         kClass.java.enumConstants.forEach {
             val valueBuilder = GraphQLEnumValueDefinition.newEnumValueDefinition()
@@ -22,7 +22,7 @@ internal class EnumTypeBuilder(generator: SchemaGenerator) : TypeBuilder(generat
             valueBuilder.value(it.name)
 
             val valueField = kClass.java.getField(it.name)
-            valueBuilder.description(valueField.graphQLDescription())
+            valueBuilder.description(valueField.getGraphQLDescription())
             valueBuilder.deprecationReason(valueField.getDeprecationReason())
 
             enumBuilder.value(valueBuilder.build())

--- a/src/main/kotlin/com/expedia/graphql/schema/generator/types/FunctionTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/generator/types/FunctionTypeBuilder.kt
@@ -4,7 +4,7 @@ import com.expedia.graphql.schema.KotlinDataFetcher
 import com.expedia.graphql.schema.Parameter
 import com.expedia.graphql.schema.extensions.directives
 import com.expedia.graphql.schema.extensions.getDeprecationReason
-import com.expedia.graphql.schema.extensions.graphQLDescription
+import com.expedia.graphql.schema.extensions.getGraphQLDescription
 import com.expedia.graphql.schema.extensions.isGraphQLContext
 import com.expedia.graphql.schema.extensions.throwIfUnathorizedInterface
 import com.expedia.graphql.schema.generator.SchemaGenerator
@@ -25,7 +25,7 @@ internal class FunctionTypeBuilder(generator: SchemaGenerator) : TypeBuilder(gen
     internal fun function(fn: KFunction<*>, target: Any? = null, abstract: Boolean = false): GraphQLFieldDefinition {
         val builder = GraphQLFieldDefinition.newFieldDefinition()
         builder.name(fn.name)
-        builder.description(fn.graphQLDescription())
+        builder.description(fn.getGraphQLDescription())
 
         fn.getDeprecationReason()?.let {
             builder.deprecate(it)
@@ -69,7 +69,7 @@ internal class FunctionTypeBuilder(generator: SchemaGenerator) : TypeBuilder(gen
         parameter.throwIfUnathorizedInterface()
         val builder = GraphQLArgument.newArgument()
             .name(parameter.name)
-            .description(parameter.graphQLDescription() ?: parameter.type.graphQLDescription())
+            .description(parameter.getGraphQLDescription() ?: parameter.type.getGraphQLDescription())
             .type(graphQLTypeOf(parameter.type, true) as GraphQLInputType)
 
         parameter.directives(generator).forEach {

--- a/src/main/kotlin/com/expedia/graphql/schema/generator/types/InputObjectTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/generator/types/InputObjectTypeBuilder.kt
@@ -1,8 +1,9 @@
 package com.expedia.graphql.schema.generator.types
 
+import com.expedia.graphql.schema.extensions.getPropertyDescription
 import com.expedia.graphql.schema.extensions.getValidProperties
-import com.expedia.graphql.schema.extensions.graphQLDescription
-import com.expedia.graphql.schema.extensions.isGraphQLID
+import com.expedia.graphql.schema.extensions.getGraphQLDescription
+import com.expedia.graphql.schema.extensions.isPropertyGraphQLID
 import com.expedia.graphql.schema.generator.SchemaGenerator
 import com.expedia.graphql.schema.generator.TypeBuilder
 import graphql.schema.GraphQLInputObjectField
@@ -17,21 +18,21 @@ internal class InputObjectTypeBuilder(generator: SchemaGenerator) : TypeBuilder(
         val name = getInputClassName(kClass)
 
         builder.name(name)
-        builder.description(kClass.graphQLDescription())
+        builder.description(kClass.getGraphQLDescription())
 
         // It does not make sense to run functions against the input types so we only process data fields
         kClass.getValidProperties(config.hooks)
-            .forEach { builder.field(inputProperty(it)) }
+            .forEach { builder.field(inputProperty(it, kClass)) }
 
         return builder.build()
     }
 
-    private fun inputProperty(prop: KProperty<*>): GraphQLInputObjectField {
+    private fun inputProperty(prop: KProperty<*>, parentClass: KClass<*>): GraphQLInputObjectField {
         val builder = GraphQLInputObjectField.newInputObjectField()
 
-        builder.description(prop.graphQLDescription())
+        builder.description(prop.getPropertyDescription(parentClass))
         builder.name(prop.name)
-        builder.type(graphQLTypeOf(prop.returnType, true, prop.isGraphQLID()) as? GraphQLInputType)
+        builder.type(graphQLTypeOf(prop.returnType, true, prop.isPropertyGraphQLID(parentClass)) as? GraphQLInputType)
 
         return builder.build()
     }

--- a/src/main/kotlin/com/expedia/graphql/schema/generator/types/InterfaceTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/generator/types/InterfaceTypeBuilder.kt
@@ -2,7 +2,7 @@ package com.expedia.graphql.schema.generator.types
 
 import com.expedia.graphql.schema.extensions.getValidFunctions
 import com.expedia.graphql.schema.extensions.getValidProperties
-import com.expedia.graphql.schema.extensions.graphQLDescription
+import com.expedia.graphql.schema.extensions.getGraphQLDescription
 import com.expedia.graphql.schema.generator.SchemaGenerator
 import com.expedia.graphql.schema.generator.TypeBuilder
 import graphql.TypeResolutionEnvironment
@@ -17,10 +17,10 @@ internal class InterfaceTypeBuilder(generator: SchemaGenerator) : TypeBuilder(ge
             val builder = GraphQLInterfaceType.newInterface()
 
             builder.name(kClass.simpleName)
-            builder.description(kClass.graphQLDescription())
+            builder.description(kClass.getGraphQLDescription())
 
             kClass.getValidProperties(config.hooks)
-                .forEach { builder.field(generator.property(it)) }
+                .forEach { builder.field(generator.property(it, kClass)) }
 
             kClass.getValidFunctions(config.hooks)
                 .forEach { builder.field(generator.function(it, abstract = true)) }

--- a/src/main/kotlin/com/expedia/graphql/schema/generator/types/ObjectTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/generator/types/ObjectTypeBuilder.kt
@@ -1,9 +1,9 @@
 package com.expedia.graphql.schema.generator.types
 
 import com.expedia.graphql.schema.extensions.directives
+import com.expedia.graphql.schema.extensions.getGraphQLDescription
 import com.expedia.graphql.schema.extensions.getValidFunctions
 import com.expedia.graphql.schema.extensions.getValidProperties
-import com.expedia.graphql.schema.extensions.graphQLDescription
 import com.expedia.graphql.schema.extensions.isGraphQLInterface
 import com.expedia.graphql.schema.extensions.isGraphQLUnion
 import com.expedia.graphql.schema.generator.SchemaGenerator
@@ -22,7 +22,7 @@ internal class ObjectTypeBuilder(generator: SchemaGenerator) : TypeBuilder(gener
             val builder = GraphQLObjectType.newObject()
 
             builder.name(kClass.simpleName)
-            builder.description(kClass.graphQLDescription())
+            builder.description(kClass.getGraphQLDescription())
 
             kClass.directives(generator).forEach {
                 builder.withDirective(it)
@@ -40,7 +40,7 @@ internal class ObjectTypeBuilder(generator: SchemaGenerator) : TypeBuilder(gener
             }
 
             kClass.getValidProperties(config.hooks)
-                .forEach { builder.field(generator.property(it)) }
+                .forEach { builder.field(generator.property(it, kClass)) }
 
             kClass.getValidFunctions(config.hooks)
                 .forEach { builder.field(generator.function(it)) }

--- a/src/main/kotlin/com/expedia/graphql/schema/generator/types/PropertyTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/generator/types/PropertyTypeBuilder.kt
@@ -1,27 +1,28 @@
 package com.expedia.graphql.schema.generator.types
 
 import com.expedia.graphql.schema.extensions.directives
-import com.expedia.graphql.schema.extensions.getDeprecationReason
-import com.expedia.graphql.schema.extensions.graphQLDescription
-import com.expedia.graphql.schema.extensions.isGraphQLID
+import com.expedia.graphql.schema.extensions.getPropertyDeprecationReason
+import com.expedia.graphql.schema.extensions.getPropertyDescription
+import com.expedia.graphql.schema.extensions.isPropertyGraphQLID
 import com.expedia.graphql.schema.generator.SchemaGenerator
 import com.expedia.graphql.schema.generator.TypeBuilder
 import graphql.schema.DataFetcherFactory
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLNonNull
 import graphql.schema.GraphQLOutputType
+import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
 @Suppress("Detekt.UnsafeCast")
 internal class PropertyTypeBuilder(generator: SchemaGenerator) : TypeBuilder(generator) {
-    internal fun property(prop: KProperty<*>): GraphQLFieldDefinition {
-        val propertyType = graphQLTypeOf(type = prop.returnType, annotatedAsID = prop.isGraphQLID()) as GraphQLOutputType
+    internal fun property(prop: KProperty<*>, parentClass: KClass<*>): GraphQLFieldDefinition {
+        val propertyType = graphQLTypeOf(type = prop.returnType, annotatedAsID = prop.isPropertyGraphQLID(parentClass)) as GraphQLOutputType
 
         val fieldBuilder = GraphQLFieldDefinition.newFieldDefinition()
-            .description(prop.graphQLDescription())
+            .description(prop.getPropertyDescription(parentClass))
             .name(prop.name)
             .type(propertyType)
-            .deprecate(prop.getDeprecationReason())
+            .deprecate(prop.getPropertyDeprecationReason(parentClass))
 
         prop.directives(generator).forEach {
             fieldBuilder.withDirective(it)

--- a/src/main/kotlin/com/expedia/graphql/schema/generator/types/UnionTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/generator/types/UnionTypeBuilder.kt
@@ -1,6 +1,6 @@
 package com.expedia.graphql.schema.generator.types
 
-import com.expedia.graphql.schema.extensions.graphQLDescription
+import com.expedia.graphql.schema.extensions.getGraphQLDescription
 import com.expedia.graphql.schema.generator.SchemaGenerator
 import com.expedia.graphql.schema.generator.TypeBuilder
 import com.expedia.graphql.schema.generator.TypesCacheKey
@@ -19,7 +19,7 @@ internal class UnionTypeBuilder(generator: SchemaGenerator) : TypeBuilder(genera
             val builder = GraphQLUnionType.newUnionType()
 
             builder.name(kClass.simpleName)
-            builder.description(kClass.graphQLDescription())
+            builder.description(kClass.getGraphQLDescription())
             builder.typeResolver { env: TypeResolutionEnvironment -> env.schema.getObjectType(env.getObject<Any>().javaClass.simpleName) }
 
             val implementations = subTypeMapper.getSubTypesOf(kClass)

--- a/src/test/kotlin/com/expedia/graphql/schema/extensions/AnnotationExtensionsTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/extensions/AnnotationExtensionsTest.kt
@@ -17,7 +17,7 @@ internal class AnnotationExtensionsTest {
     @Deprecated("class deprecated")
     @GraphQLIgnore
     private data class WithAnnotations(
-        @Deprecated("property deprecated")
+        @property:Deprecated("property deprecated")
         @property:GraphQLDescription("property description")
         @property:GraphQLID
         val id: String
@@ -25,34 +25,19 @@ internal class AnnotationExtensionsTest {
 
     private data class NoAnnotations(val id: String)
 
-    private enum class AnnotatedEnum {
-        @GraphQLDescription("field description")
-        @Deprecated("do not use", ReplaceWith("TWO"))
-        ONE,
-        TWO
-    }
-
     @Test
     fun `verify @GraphQLDescrption on classes`() {
-        assertEquals(expected = "class description", actual = WithAnnotations::class.graphQLDescription())
-        assertNull(NoAnnotations::class.graphQLDescription())
-    }
-
-    @Test
-    fun `verify @GraphQLDescrption on fields`() {
-        val description = AnnotatedEnum::class.java.getField("ONE")
-        val noDescription = AnnotatedEnum::class.java.getField("TWO")
-        assertEquals(expected = "field description", actual = description.graphQLDescription())
-        assertNull(noDescription.graphQLDescription())
+        assertEquals(expected = "class description", actual = WithAnnotations::class.getGraphQLDescription())
+        assertNull(NoAnnotations::class.getGraphQLDescription())
     }
 
     @Test
     fun `verify @Deprecated`() {
         val classDeprecation = WithAnnotations::class.getDeprecationReason()
-        val propertyDeprecation = AnnotatedEnum::class.java.getField("ONE")?.getDeprecationReason()
+        val classPropertyDeprecation = WithAnnotations::class.declaredMemberProperties.find { it.name == "id" }?.getDeprecationReason()
 
         assertEquals(expected = "class deprecated", actual = classDeprecation)
-        assertEquals(expected = "do not use, replace with TWO", actual = propertyDeprecation)
+        assertEquals(expected = "property deprecated", actual = classPropertyDeprecation)
         assertNull(NoAnnotations::class.getDeprecationReason())
     }
 
@@ -66,7 +51,7 @@ internal class AnnotationExtensionsTest {
     fun `verify @GraphQLID`() {
         val id = WithAnnotations::class.declaredMemberProperties.find { it.name == "id" }
         val notId = NoAnnotations::class.declaredMemberProperties.find { it.name == "id" }
-        assertTrue { id?.isGraphQLID() == true }
-        assertTrue { notId?.isGraphQLID() == false }
+        assertTrue { id?.isGraphQLID().isTrue() }
+        assertFalse { notId?.isGraphQLID().isTrue() }
     }
 }

--- a/src/test/kotlin/com/expedia/graphql/schema/extensions/BooleanExtensionsKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/extensions/BooleanExtensionsKtTest.kt
@@ -1,0 +1,15 @@
+package com.expedia.graphql.schema.extensions
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class BooleanExtensionsKtTest {
+
+    @Test
+    fun isTrue() {
+        assertFalse(null.isTrue())
+        assertFalse(false.isTrue())
+        assertTrue(true.isTrue())
+    }
+}

--- a/src/test/kotlin/com/expedia/graphql/schema/extensions/FieldExtenstionsKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/extensions/FieldExtenstionsKtTest.kt
@@ -1,0 +1,30 @@
+package com.expedia.graphql.schema.extensions
+
+import com.expedia.graphql.annotations.GraphQLDescription
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class FieldExtenstionsKtTest {
+
+    internal enum class AnnotatedEnum {
+        @GraphQLDescription("field description")
+        @Deprecated("do not use", ReplaceWith("TWO"))
+        ONE,
+        TWO
+    }
+
+    @Test
+    fun `verify @GraphQLDescrption on fields`() {
+        val description = AnnotatedEnum::class.java.getField("ONE")
+        val noDescription = AnnotatedEnum::class.java.getField("TWO")
+        assertEquals(expected = "field description", actual = description.getGraphQLDescription())
+        assertNull(noDescription.getGraphQLDescription())
+    }
+
+    @Test
+    fun `verify @Deprecated on fields`() {
+        val propertyDeprecation = AnnotatedEnum::class.java.getField("ONE")?.getDeprecationReason()
+        assertEquals(expected = "do not use, replace with TWO", actual = propertyDeprecation)
+    }
+}

--- a/src/test/kotlin/com/expedia/graphql/schema/extensions/KClassExtensionsTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/extensions/KClassExtensionsTest.kt
@@ -32,6 +32,10 @@ internal class KClassExtensionsTest {
         TWO
     }
 
+    private class EmptyConstructorClass {
+        val id = 1
+    }
+
     private interface TestInterface
 
     private interface InvalidPropertyUnionInterface {
@@ -82,6 +86,8 @@ internal class KClassExtensionsTest {
     fun `test findConstructorParamter`() {
         assertNotNull(MyTestClass::class.findConstructorParamter("publicProperty"))
         assertNull(MyTestClass::class.findConstructorParamter("foobar"))
+        assertNull(EmptyConstructorClass::class.findConstructorParamter("id"))
+        assertNull(TestInterface::class.findConstructorParamter("foobar"))
     }
 
     @Test

--- a/src/test/kotlin/com/expedia/graphql/schema/extensions/KClassExtensionsTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/extensions/KClassExtensionsTest.kt
@@ -7,6 +7,8 @@ import kotlin.reflect.KProperty
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @Suppress("Detekt.UnusedPrivateClass")
@@ -74,6 +76,12 @@ internal class KClassExtensionsTest {
     fun `test getting valid functions with filter hooks`() {
         val properties = MyTestClass::class.getValidFunctions(FilterHooks())
         assertEquals(listOf("publicFunction"), properties.map { it.name })
+    }
+
+    @Test
+    fun `test findConstructorParamter`() {
+        assertNotNull(MyTestClass::class.findConstructorParamter("publicProperty"))
+        assertNull(MyTestClass::class.findConstructorParamter("foobar"))
     }
 
     @Test

--- a/src/test/kotlin/com/expedia/graphql/schema/extensions/KPropertyExtensionsKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/extensions/KPropertyExtensionsKtTest.kt
@@ -20,12 +20,6 @@ internal class KPropertyExtensionsKtTest {
         @property:GraphQLIgnore
         val propertyAnnotation: String,
 
-        @property:Deprecated("property Int deprecated")
-        @property:GraphQLDescription("property Int description")
-        @property:GraphQLID
-        @property:GraphQLIgnore
-        val propertyAnnotationInt: Int,
-
         @Deprecated("constructor deprecated")
         @GraphQLDescription("constructor description")
         @GraphQLID
@@ -38,7 +32,6 @@ internal class KPropertyExtensionsKtTest {
     @Test
     fun isPropertyGraphQLID() {
         assertTrue(MyClass::propertyAnnotation.isPropertyGraphQLID(MyClass::class))
-        assertTrue(MyClass::propertyAnnotationInt.isPropertyGraphQLID(MyClass::class))
         assertTrue(MyClass::constructorAnnotation.isPropertyGraphQLID(MyClass::class))
         assertFalse(MyClass::noAnnotations.isPropertyGraphQLID(MyClass::class))
     }
@@ -46,7 +39,6 @@ internal class KPropertyExtensionsKtTest {
     @Test
     fun isPropertyGraphQLIgnored() {
         assertTrue(MyClass::propertyAnnotation.isPropertyGraphQLIgnored(MyClass::class))
-        assertTrue(MyClass::propertyAnnotationInt.isPropertyGraphQLIgnored(MyClass::class))
         assertTrue(MyClass::constructorAnnotation.isPropertyGraphQLIgnored(MyClass::class))
         assertFalse(MyClass::noAnnotations.isPropertyGraphQLIgnored(MyClass::class))
     }
@@ -54,7 +46,6 @@ internal class KPropertyExtensionsKtTest {
     @Test
     fun getPropertyDeprecationReason() {
         assertEquals("property deprecated", MyClass::propertyAnnotation.getPropertyDeprecationReason(MyClass::class))
-        assertEquals("property Int deprecated", MyClass::propertyAnnotationInt.getPropertyDeprecationReason(MyClass::class))
         assertEquals("constructor deprecated", MyClass::constructorAnnotation.getPropertyDeprecationReason(MyClass::class))
         assertEquals(null, MyClass::noAnnotations.getPropertyDeprecationReason(MyClass::class))
     }
@@ -62,7 +53,6 @@ internal class KPropertyExtensionsKtTest {
     @Test
     fun getPropertyDescription() {
         assertEquals("property description", MyClass::propertyAnnotation.getPropertyDescription(MyClass::class))
-        assertEquals("property Int description", MyClass::propertyAnnotationInt.getPropertyDescription(MyClass::class))
         assertEquals("constructor description", MyClass::constructorAnnotation.getPropertyDescription(MyClass::class))
         assertEquals(null, MyClass::noAnnotations.getPropertyDescription(MyClass::class))
     }

--- a/src/test/kotlin/com/expedia/graphql/schema/extensions/KPropertyExtensionsKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/extensions/KPropertyExtensionsKtTest.kt
@@ -13,12 +13,18 @@ internal class KPropertyExtensionsKtTest {
     /**
      * Annotations can be on the property or on the contructor argument
      */
-    internal data class MyDataClass(
+    internal class MyClass(
         @property:Deprecated("property deprecated")
         @property:GraphQLDescription("property description")
         @property:GraphQLID
         @property:GraphQLIgnore
         val propertyAnnotation: String,
+
+        @property:Deprecated("property Int deprecated")
+        @property:GraphQLDescription("property Int description")
+        @property:GraphQLID
+        @property:GraphQLIgnore
+        val propertyAnnotationInt: Int,
 
         @Deprecated("constructor deprecated")
         @GraphQLDescription("constructor description")
@@ -31,29 +37,33 @@ internal class KPropertyExtensionsKtTest {
 
     @Test
     fun isPropertyGraphQLID() {
-        assertTrue(MyDataClass::propertyAnnotation.isPropertyGraphQLID(MyDataClass::class))
-        assertTrue(MyDataClass::constructorAnnotation.isPropertyGraphQLID(MyDataClass::class))
-        assertFalse(MyDataClass::noAnnotations.isPropertyGraphQLID(MyDataClass::class))
+        assertTrue(MyClass::propertyAnnotation.isPropertyGraphQLID(MyClass::class))
+        assertTrue(MyClass::propertyAnnotationInt.isPropertyGraphQLID(MyClass::class))
+        assertTrue(MyClass::constructorAnnotation.isPropertyGraphQLID(MyClass::class))
+        assertFalse(MyClass::noAnnotations.isPropertyGraphQLID(MyClass::class))
     }
 
     @Test
     fun isPropertyGraphQLIgnored() {
-        assertTrue(MyDataClass::propertyAnnotation.isPropertyGraphQLIgnored(MyDataClass::class))
-        assertTrue(MyDataClass::constructorAnnotation.isPropertyGraphQLIgnored(MyDataClass::class))
-        assertFalse(MyDataClass::noAnnotations.isPropertyGraphQLIgnored(MyDataClass::class))
+        assertTrue(MyClass::propertyAnnotation.isPropertyGraphQLIgnored(MyClass::class))
+        assertTrue(MyClass::propertyAnnotationInt.isPropertyGraphQLIgnored(MyClass::class))
+        assertTrue(MyClass::constructorAnnotation.isPropertyGraphQLIgnored(MyClass::class))
+        assertFalse(MyClass::noAnnotations.isPropertyGraphQLIgnored(MyClass::class))
     }
 
     @Test
     fun getPropertyDeprecationReason() {
-        assertEquals("property deprecated", MyDataClass::propertyAnnotation.getPropertyDeprecationReason(MyDataClass::class))
-        assertEquals("constructor deprecated", MyDataClass::constructorAnnotation.getPropertyDeprecationReason(MyDataClass::class))
-        assertEquals(null, MyDataClass::noAnnotations.getPropertyDeprecationReason(MyDataClass::class))
+        assertEquals("property deprecated", MyClass::propertyAnnotation.getPropertyDeprecationReason(MyClass::class))
+        assertEquals("property Int deprecated", MyClass::propertyAnnotationInt.getPropertyDeprecationReason(MyClass::class))
+        assertEquals("constructor deprecated", MyClass::constructorAnnotation.getPropertyDeprecationReason(MyClass::class))
+        assertEquals(null, MyClass::noAnnotations.getPropertyDeprecationReason(MyClass::class))
     }
 
     @Test
     fun getPropertyDescription() {
-        assertEquals("property description", MyDataClass::propertyAnnotation.getPropertyDescription(MyDataClass::class))
-        assertEquals("constructor description", MyDataClass::constructorAnnotation.getPropertyDescription(MyDataClass::class))
-        assertEquals(null, MyDataClass::noAnnotations.getPropertyDescription(MyDataClass::class))
+        assertEquals("property description", MyClass::propertyAnnotation.getPropertyDescription(MyClass::class))
+        assertEquals("property Int description", MyClass::propertyAnnotationInt.getPropertyDescription(MyClass::class))
+        assertEquals("constructor description", MyClass::constructorAnnotation.getPropertyDescription(MyClass::class))
+        assertEquals(null, MyClass::noAnnotations.getPropertyDescription(MyClass::class))
     }
 }

--- a/src/test/kotlin/com/expedia/graphql/schema/extensions/KPropertyExtensionsKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/extensions/KPropertyExtensionsKtTest.kt
@@ -13,7 +13,7 @@ internal class KPropertyExtensionsKtTest {
     /**
      * Annotations can be on the property or on the contructor argument
      */
-    internal class MyClass(
+    internal data class MyDataClass(
         @property:Deprecated("property deprecated")
         @property:GraphQLDescription("property description")
         @property:GraphQLID
@@ -31,29 +31,29 @@ internal class KPropertyExtensionsKtTest {
 
     @Test
     fun isPropertyGraphQLID() {
-        assertTrue(MyClass::propertyAnnotation.isPropertyGraphQLID(MyClass::class))
-        assertTrue(MyClass::constructorAnnotation.isPropertyGraphQLID(MyClass::class))
-        assertFalse(MyClass::noAnnotations.isPropertyGraphQLID(MyClass::class))
+        assertTrue(MyDataClass::propertyAnnotation.isPropertyGraphQLID(MyDataClass::class))
+        assertTrue(MyDataClass::constructorAnnotation.isPropertyGraphQLID(MyDataClass::class))
+        assertFalse(MyDataClass::noAnnotations.isPropertyGraphQLID(MyDataClass::class))
     }
 
     @Test
     fun isPropertyGraphQLIgnored() {
-        assertTrue(MyClass::propertyAnnotation.isPropertyGraphQLIgnored(MyClass::class))
-        assertTrue(MyClass::constructorAnnotation.isPropertyGraphQLIgnored(MyClass::class))
-        assertFalse(MyClass::noAnnotations.isPropertyGraphQLIgnored(MyClass::class))
+        assertTrue(MyDataClass::propertyAnnotation.isPropertyGraphQLIgnored(MyDataClass::class))
+        assertTrue(MyDataClass::constructorAnnotation.isPropertyGraphQLIgnored(MyDataClass::class))
+        assertFalse(MyDataClass::noAnnotations.isPropertyGraphQLIgnored(MyDataClass::class))
     }
 
     @Test
     fun getPropertyDeprecationReason() {
-        assertEquals("property deprecated", MyClass::propertyAnnotation.getPropertyDeprecationReason(MyClass::class))
-        assertEquals("constructor deprecated", MyClass::constructorAnnotation.getPropertyDeprecationReason(MyClass::class))
-        assertEquals(null, MyClass::noAnnotations.getPropertyDeprecationReason(MyClass::class))
+        assertEquals("property deprecated", MyDataClass::propertyAnnotation.getPropertyDeprecationReason(MyDataClass::class))
+        assertEquals("constructor deprecated", MyDataClass::constructorAnnotation.getPropertyDeprecationReason(MyDataClass::class))
+        assertEquals(null, MyDataClass::noAnnotations.getPropertyDeprecationReason(MyDataClass::class))
     }
 
     @Test
     fun getPropertyDescription() {
-        assertEquals("property description", MyClass::propertyAnnotation.getPropertyDescription(MyClass::class))
-        assertEquals("constructor description", MyClass::constructorAnnotation.getPropertyDescription(MyClass::class))
-        assertEquals(null, MyClass::noAnnotations.getPropertyDescription(MyClass::class))
+        assertEquals("property description", MyDataClass::propertyAnnotation.getPropertyDescription(MyDataClass::class))
+        assertEquals("constructor description", MyDataClass::constructorAnnotation.getPropertyDescription(MyDataClass::class))
+        assertEquals(null, MyDataClass::noAnnotations.getPropertyDescription(MyDataClass::class))
     }
 }

--- a/src/test/kotlin/com/expedia/graphql/schema/extensions/KPropertyExtensionsKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/extensions/KPropertyExtensionsKtTest.kt
@@ -1,0 +1,59 @@
+package com.expedia.graphql.schema.extensions
+
+import com.expedia.graphql.annotations.GraphQLDescription
+import com.expedia.graphql.annotations.GraphQLID
+import com.expedia.graphql.annotations.GraphQLIgnore
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class KPropertyExtensionsKtTest {
+
+    /**
+     * Annotations can be on the property or on the contructor argument
+     */
+    internal data class MyDataClass(
+        @property:Deprecated("property deprecated")
+        @property:GraphQLDescription("property description")
+        @property:GraphQLID
+        @property:GraphQLIgnore
+        val propertyAnnotation: String,
+
+        @Deprecated("constructor deprecated")
+        @GraphQLDescription("constructor description")
+        @GraphQLID
+        @GraphQLIgnore
+        val constructorAnnotation: String,
+
+        val noAnnotations: String
+    )
+
+    @Test
+    fun isPropertyGraphQLID() {
+        assertTrue(MyDataClass::propertyAnnotation.isPropertyGraphQLID(MyDataClass::class))
+        assertTrue(MyDataClass::constructorAnnotation.isPropertyGraphQLID(MyDataClass::class))
+        assertFalse(MyDataClass::noAnnotations.isPropertyGraphQLID(MyDataClass::class))
+    }
+
+    @Test
+    fun isPropertyGraphQLIgnored() {
+        assertTrue(MyDataClass::propertyAnnotation.isPropertyGraphQLIgnored(MyDataClass::class))
+        assertTrue(MyDataClass::constructorAnnotation.isPropertyGraphQLIgnored(MyDataClass::class))
+        assertFalse(MyDataClass::noAnnotations.isPropertyGraphQLIgnored(MyDataClass::class))
+    }
+
+    @Test
+    fun getPropertyDeprecationReason() {
+        assertEquals("property deprecated", MyDataClass::propertyAnnotation.getPropertyDeprecationReason(MyDataClass::class))
+        assertEquals("constructor deprecated", MyDataClass::constructorAnnotation.getPropertyDeprecationReason(MyDataClass::class))
+        assertEquals(null, MyDataClass::noAnnotations.getPropertyDeprecationReason(MyDataClass::class))
+    }
+
+    @Test
+    fun getPropertyDescription() {
+        assertEquals("property description", MyDataClass::propertyAnnotation.getPropertyDescription(MyDataClass::class))
+        assertEquals("constructor description", MyDataClass::constructorAnnotation.getPropertyDescription(MyDataClass::class))
+        assertEquals(null, MyDataClass::noAnnotations.getPropertyDescription(MyDataClass::class))
+    }
+}

--- a/src/test/kotlin/com/expedia/graphql/schema/extensions/KTypeExtensionsKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/extensions/KTypeExtensionsKtTest.kt
@@ -1,0 +1,47 @@
+package com.expedia.graphql.schema.extensions
+
+import com.expedia.graphql.schema.exceptions.InvalidListTypeException
+import org.junit.jupiter.api.Test
+import kotlin.reflect.full.findParameterByName
+import kotlin.reflect.full.starProjectedType
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+internal class KTypeExtensionsKtTest {
+
+    internal class MyClass {
+        fun listFun(list: List<String>) = list.joinToString(separator = ",") { it }
+
+        fun stringFun(string: String) = "hello $string"
+    }
+
+    @Test
+    fun getTypeOfFirstArgument() {
+        assertEquals(String::class.starProjectedType, MyClass::listFun.findParameterByName("list")?.type?.getTypeOfFirstArgument())
+
+        assertFailsWith(InvalidListTypeException::class) {
+            MyClass::stringFun.findParameterByName("string")?.type?.getTypeOfFirstArgument()
+        }
+    }
+
+    @Test
+    fun getKClass() {
+        assertEquals(MyClass::class, MyClass::class.starProjectedType.getKClass())
+    }
+
+    @Test
+    fun getArrayType() {
+        assertEquals(Int::class.starProjectedType, IntArray::class.starProjectedType.getArrayType())
+        assertEquals(Long::class.starProjectedType, LongArray::class.starProjectedType.getArrayType())
+        assertEquals(Short::class.starProjectedType, ShortArray::class.starProjectedType.getArrayType())
+        assertEquals(Float::class.starProjectedType, FloatArray::class.starProjectedType.getArrayType())
+        assertEquals(Double::class.starProjectedType, DoubleArray::class.starProjectedType.getArrayType())
+        assertEquals(Char::class.starProjectedType, CharArray::class.starProjectedType.getArrayType())
+        assertEquals(Boolean::class.starProjectedType, BooleanArray::class.starProjectedType.getArrayType())
+        assertEquals(String::class.starProjectedType, MyClass::listFun.findParameterByName("list")?.type?.getArrayType())
+
+        assertFailsWith(InvalidListTypeException::class) {
+            MyClass::stringFun.findParameterByName("string")?.type?.getArrayType()
+        }
+    }
+}

--- a/src/test/kotlin/com/expedia/graphql/schema/generator/SchemaFiltersTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/generator/SchemaFiltersTest.kt
@@ -1,6 +1,7 @@
 package com.expedia.graphql.schema.generator
 
 import com.expedia.graphql.annotations.GraphQLIgnore
+import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty
 import kotlin.reflect.full.declaredMemberFunctions
@@ -12,7 +13,12 @@ import kotlin.test.assertTrue
 @Suppress("Detekt.UnusedPrivateClass")
 internal class SchemaFiltersTest {
 
-    private data class MyDataClass(val id: Int = 0)
+    private data class MyDataClass(
+        val id: Int = 0,
+
+        @GraphQLIgnore
+        internal val ignoredProperty: Int = 0
+    )
 
     private class MyClass {
 
@@ -47,13 +53,14 @@ internal class SchemaFiltersTest {
 
     @Test
     fun `test property filters`() {
-        assertTrue(testProperty(MyClass::publicProperty))
-        assertFalse(testProperty(MyClass::nonPublicProperty))
-        assertFalse(testProperty(MyClass::ignoredProperty))
-        assertTrue(testProperty(MyDataClass::id))
+        assertTrue(testProperty(MyClass::publicProperty, MyClass::class))
+        assertFalse(testProperty(MyClass::nonPublicProperty, MyClass::class))
+        assertFalse(testProperty(MyClass::ignoredProperty, MyClass::class))
+        assertTrue(testProperty(MyDataClass::id, MyDataClass::class))
+        assertFalse(testProperty(MyDataClass::ignoredProperty, MyDataClass::class))
     }
 
     private fun testFunction(function: KFunction<*>): Boolean = functionFilters.all { it(function) }
 
-    private fun testProperty(property: KProperty<*>): Boolean = propertyFilters.all { it(property) }
+    private fun testProperty(property: KProperty<*>, parentClass: KClass<*>): Boolean = propertyFilters.all { it(property, parentClass) }
 }

--- a/src/test/kotlin/com/expedia/graphql/schema/generator/SchemaGeneratorTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/generator/SchemaGeneratorTest.kt
@@ -404,13 +404,13 @@ class SchemaGeneratorTest {
     data class Person(val name: String, val children: List<Person>? = null)
 
     data class PlaceOfIds(
-        @property:GraphQLID val intId: Int,
-        @property:GraphQLID val longId: Long,
-        @property:GraphQLID val stringId: String,
-        @property:GraphQLID val uuid: UUID
+        @GraphQLID val intId: Int,
+        @GraphQLID val longId: Long,
+        @GraphQLID val stringId: String,
+        @GraphQLID val uuid: UUID
     )
 
-    data class InvalidIds(@property:GraphQLID val person: Person)
+    data class InvalidIds(@GraphQLID val person: Person)
 
     class QueryWithId {
         fun query(): PlaceOfIds = PlaceOfIds(42, 24, "42", UUID.randomUUID())
@@ -425,7 +425,7 @@ class SchemaGeneratorTest {
     }
 
     data class Furniture(
-        @property:GraphQLID val serial: UUID,
+        @GraphQLID val serial: UUID,
         val type: String
     )
 }

--- a/src/test/kotlin/com/expedia/graphql/schema/generator/types/PropertyTypeTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/generator/types/PropertyTypeTest.kt
@@ -2,9 +2,11 @@ package com.expedia.graphql.schema.generator.types
 
 import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.annotations.GraphQLDirective
+import com.expedia.graphql.annotations.GraphQLID
 import com.expedia.graphql.schema.extensions.getValidProperties
 import graphql.Scalars
 import graphql.introspection.Introspection
+import graphql.schema.GraphQLNonNull
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -25,6 +27,14 @@ internal class PropertyTypeTest : TypeTestHelper() {
         lateinit var healthyFood: String
     }
 
+    private data class DataClassWithProperties(
+        @GraphQLDescription("A great description")
+        val fooBar: String,
+
+        @GraphQLID
+        val myId: String
+    )
+
     private lateinit var builder: PropertyTypeBuilder
 
     override fun beforeTest() {
@@ -34,7 +44,7 @@ internal class PropertyTypeTest : TypeTestHelper() {
     @Test
     fun `Test naming`() {
         val prop = ClassWithProperties::class.getValidProperties(hooks)[0]
-        val result = builder.property(prop)
+        val result = builder.property(prop, ClassWithProperties::class)
 
         assertEquals("cake", result.name)
     }
@@ -42,7 +52,7 @@ internal class PropertyTypeTest : TypeTestHelper() {
     @Test
     fun `Test deprecation`() {
         val prop = ClassWithProperties::class.getValidProperties(hooks)[0]
-        val result = builder.property(prop)
+        val result = builder.property(prop, ClassWithProperties::class)
 
         assertTrue(result.isDeprecated)
         assertEquals("It's not a lie", result.deprecationReason)
@@ -51,7 +61,7 @@ internal class PropertyTypeTest : TypeTestHelper() {
     @Test
     fun `Test deprecation with replacement`() {
         val prop = ClassWithProperties::class.getValidProperties(hooks)[1]
-        val result = builder.property(prop)
+        val result = builder.property(prop, ClassWithProperties::class)
 
         assertTrue(result.isDeprecated)
         assertEquals("Healthy food is deprecated, replace with cake", result.deprecationReason)
@@ -60,15 +70,31 @@ internal class PropertyTypeTest : TypeTestHelper() {
     @Test
     fun `Test description`() {
         val prop = ClassWithProperties::class.getValidProperties(hooks)[0]
-        val result = builder.property(prop)
+        val result = builder.property(prop, ClassWithProperties::class)
 
         assertEquals("The truth", result.description)
     }
 
     @Test
+    fun `Test description on data class`() {
+        val prop = DataClassWithProperties::class.getValidProperties(hooks)[0]
+        val result = builder.property(prop, DataClassWithProperties::class)
+
+        assertEquals("A great description", result.description)
+    }
+
+    @Test
+    fun `Test graphql id on data class`() {
+        val prop = DataClassWithProperties::class.getValidProperties(hooks)[1]
+        val result = builder.property(prop, DataClassWithProperties::class)
+
+        assertEquals("ID", (result.type as? GraphQLNonNull)?.wrappedType?.name)
+    }
+
+    @Test
     fun `Test custom directive`() {
         val prop = ClassWithProperties::class.getValidProperties(hooks)[0]
-        val result = builder.property(prop)
+        val result = builder.property(prop, ClassWithProperties::class)
 
         assertEquals(1, result.directives.size)
         val directive = result.directives[0]


### PR DESCRIPTION
The issue was only with class properties. We couldn't set the annotation target because we also need the annotation to be valid on function arguments so classes still default the annotation to the constructor function arguments.

We need to check 4 possible annotation on a property:
* `@Deprecated`
* `@GraphQLDescription`
* `@GraphQLID`
* `@GraphQLIgnore`

The way I get around this is I first check if the property has the annotation, which is what we do right now so `@property:` prefixed annotations are handled first. If I can't find anything there I look at the parent class constructor, check it's arguments for a matching type (see  `KClass<*>.findConstructorParamter`), and return any annotations there, or default to null/false

A good example of the changes is in `KPropertyExtensionsKtTest`

-----------------------
Here is the changes I made to the example app code

![screen shot 2018-12-13 at 11 36 27 am](https://user-images.githubusercontent.com/2446877/49963443-daa79780-fecc-11e8-90e4-76bc8c837b91.png)


And here is the docs in GraphiQL

![screen shot 2018-12-13 at 11 36 04 am](https://user-images.githubusercontent.com/2446877/49963463-e2ffd280-fecc-11e8-9988-e733ea151f33.png)
