### PR TITLE
keep custom directive names if they are specified

### DIFF
--- a/example/src/main/kotlin/com.expedia.graphql.sample/Application.kt
+++ b/example/src/main/kotlin/com.expedia.graphql.sample/Application.kt
@@ -67,7 +67,6 @@ class Application {
                 SchemaPrinter.Options.defaultOptions()
                         .includeScalarTypes(true)
                         .includeExtendedScalarTypes(true)
-                        .includeIntrospectionTypes(true)
                         .includeSchemaDefintion(true)
             ).print(schema)
         )

--- a/src/main/kotlin/com/expedia/graphql/schema/extensions/directiveExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/schema/extensions/directiveExtensions.kt
@@ -28,7 +28,7 @@ private fun DirectiveInfo.getGraphQLDirective(generator: SchemaGenerator): graph
 
     @Suppress("Detekt.SpreadOperator")
     val builder = graphql.schema.GraphQLDirective.newDirective()
-        .name(name.normalizeDirectiveName())
+        .name(name)
         .validLocations(*this.directiveAnnotation.locations)
         .description(this.directiveAnnotation.description)
 
@@ -54,7 +54,7 @@ private fun String.normalizeDirectiveName() = CaseFormat.UPPER_CAMEL.to(CaseForm
 private data class DirectiveInfo(val directive: Annotation, val directiveAnnotation: GraphQLDirective) {
     val effectiveName: String? = when {
         directiveAnnotation.name.isNotEmpty() -> directiveAnnotation.name
-        directive.annotationClass.simpleName.isNullOrEmpty().not() -> directive.annotationClass.simpleName
+        directive.annotationClass.simpleName.isNullOrBlank().not() -> directive.annotationClass.simpleName?.normalizeDirectiveName()
         else -> null
     }
 }

--- a/src/test/kotlin/com/expedia/graphql/schema/generator/DirectiveTests.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/generator/DirectiveTests.kt
@@ -45,22 +45,34 @@ class DirectiveTests {
     }
 
     @Test
-    fun `Directive renaming`() {
+    fun `Default directive names are normalized`() {
         val schema = toSchema(listOf(TopLevelObjectDef(QueryObject())), config = testSchemaConfig)
 
-        val renamedDirective = assertNotNull(
-            (schema.getType("Location") as? GraphQLObjectType)
-                ?.getDirective("rightNameDirective")
+        val query = schema.queryType.getFieldDefinition("query")
+        assertNotNull(query)
+        assertNotNull(query.getDirective("dummyDirective"))
+    }
+
+    @Test
+    fun `Custom directive names are not modified`() {
+        val schema = toSchema(listOf(TopLevelObjectDef(QueryObject())), config = testSchemaConfig)
+
+        val directive = assertNotNull(
+                (schema.getType("Location") as? GraphQLObjectType)
+                        ?.getDirective("RightNameDirective")
         )
 
-        assertEquals("arenaming", renamedDirective.arguments[0].value)
-        assertEquals("arg", renamedDirective.arguments[0].name)
-        assertEquals(Scalars.GraphQLString, renamedDirective.arguments[0].type)
+        assertEquals("arenaming", directive.arguments[0].value)
+        assertEquals("arg", directive.arguments[0].name)
+        assertEquals(Scalars.GraphQLString, directive.arguments[0].type)
     }
 }
 
 @GraphQLDirective(name = "RightNameDirective")
 annotation class WrongNameDirective(val arg: String)
+
+@GraphQLDirective
+annotation class DummyDirective
 
 class Geography(
     val id: Int?,
@@ -79,6 +91,8 @@ enum class GeoType {
 data class Location(val lat: Double, val lon: Double)
 
 class QueryObject {
+
+    @DummyDirective
     fun query(value: Int): Geography = Geography(value, GeoType.CITY, listOf())
 }
 

--- a/src/test/kotlin/com/expedia/graphql/schema/generator/directive/DirectiveWiringHelperTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/schema/generator/directive/DirectiveWiringHelperTest.kt
@@ -61,7 +61,7 @@ internal class DirectiveWiringHelperTest {
                 null
             }
 
-        override fun providesSchemaDirectiveWiring(environment: SchemaDirectiveWiringEnvironment<*>): Boolean = true
+        override fun providesSchemaDirectiveWiring(environment: SchemaDirectiveWiringEnvironment<*>): Boolean = environment.directive.name == "lowercase"
     }
 
     @Test


### PR DESCRIPTION
We should only normalize the default (class name) directive names.