### PR TITLE
refactor: extract simple name for better test coverage

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetJvmNameOfKTypeException.kt
+++ b/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetJvmNameOfKTypeException.kt
@@ -1,9 +1,0 @@
-package com.expedia.graphql.exceptions
-
-import kotlin.reflect.KType
-
-/**
- * Thrown when trying to generate a class and cannot resolve the jvm erasure name.
- */
-class CouldNotGetJvmNameOfKTypeException(kType: KType?)
-    : GraphQLKotlinException("Could not get the name of the KClass $kType")

--- a/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetNameOfAnnotationException.kt
+++ b/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetNameOfAnnotationException.kt
@@ -1,9 +1,0 @@
-package com.expedia.graphql.exceptions
-
-import kotlin.reflect.KClass
-
-/**
- * Thrown when unable to get the annotaiton name of a KAnnotatedElement.
- */
-class CouldNotGetNameOfAnnotationException(kClass: KClass<*>)
-    : GraphQLKotlinException("Could not get name of annotation class $kClass")

--- a/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetNameOfEnumException.kt
+++ b/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetNameOfEnumException.kt
@@ -1,9 +1,0 @@
-package com.expedia.graphql.exceptions
-
-import kotlin.reflect.KClass
-
-/**
- * Thrown when trying to generate an enum class and cannot resolve the simple name.
- */
-class CouldNotGetNameOfEnumException(kclass: KClass<*>)
-    : GraphQLKotlinException("Could not get the enum name of the KClass $kclass")

--- a/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetNameOfKClassException.kt
+++ b/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetNameOfKClassException.kt
@@ -3,7 +3,7 @@ package com.expedia.graphql.exceptions
 import kotlin.reflect.KClass
 
 /**
- * Thrown when trying to generate a class and cannot resolve the simple name.
+ * Thrown when trying to generate a class and cannot resolve the name.
  */
 class CouldNotGetNameOfKClassException(kclass: KClass<*>)
     : GraphQLKotlinException("Could not get the name of the KClass $kclass")

--- a/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetNameOfKClassException.kt
+++ b/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetNameOfKClassException.kt
@@ -1,0 +1,9 @@
+package com.expedia.graphql.exceptions
+
+import kotlin.reflect.KClass
+
+/**
+ * Thrown when trying to generate a class and cannot resolve the simple name.
+ */
+class CouldNotGetNameOfKClassException(kclass: KClass<*>)
+    : GraphQLKotlinException("Could not get the name of the KClass $kclass")

--- a/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetNameOfKParameterException.kt
+++ b/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetNameOfKParameterException.kt
@@ -3,7 +3,7 @@ package com.expedia.graphql.exceptions
 import kotlin.reflect.KParameter
 
 /**
- * Thrown when unable to get the simple name of a function argument
+ * Thrown when trying to generate a parameter and cannot resolve the name.
  */
 class CouldNotGetNameOfKParameterException(kParameter: KParameter)
     : GraphQLKotlinException("Could not get name of the KParameter $kParameter")

--- a/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetNameOfKParameterException.kt
+++ b/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetNameOfKParameterException.kt
@@ -5,5 +5,5 @@ import kotlin.reflect.KParameter
 /**
  * Thrown when unable to get the simple name of a function argument
  */
-class CouldNotGetNameOfArgumentException(kParameter: KParameter)
-    : GraphQLKotlinException("Could not get name of parameter $kParameter")
+class CouldNotGetNameOfKParameterException(kParameter: KParameter)
+    : GraphQLKotlinException("Could not get name of the KParameter $kParameter")

--- a/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetNameOfKTypeException.kt
+++ b/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetNameOfKTypeException.kt
@@ -3,7 +3,7 @@ package com.expedia.graphql.exceptions
 import kotlin.reflect.KType
 
 /**
- * Thrown when trying to generate a type and cannot resolve the simple name.
+ * Thrown when trying to generate a type and cannot resolve the name.
  */
 class CouldNotGetNameOfKTypeException(kType: KType)
     : GraphQLKotlinException("Could not get the name of the KType $kType")

--- a/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetNameOfKTypeException.kt
+++ b/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetNameOfKTypeException.kt
@@ -1,0 +1,9 @@
+package com.expedia.graphql.exceptions
+
+import kotlin.reflect.KType
+
+/**
+ * Thrown when trying to generate a type and cannot resolve the simple name.
+ */
+class CouldNotGetNameOfKTypeException(kType: KType)
+    : GraphQLKotlinException("Could not get the name of the KType $kType")

--- a/src/main/kotlin/com/expedia/graphql/generator/TypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/TypeBuilder.kt
@@ -3,9 +3,9 @@ package com.expedia.graphql.generator
 import com.expedia.graphql.generator.extensions.getKClass
 import com.expedia.graphql.generator.extensions.isArray
 import com.expedia.graphql.generator.extensions.isEnum
-import com.expedia.graphql.generator.extensions.isGraphQLInterface
-import com.expedia.graphql.generator.extensions.isGraphQLUnion
+import com.expedia.graphql.generator.extensions.isInterface
 import com.expedia.graphql.generator.extensions.isList
+import com.expedia.graphql.generator.extensions.isUnion
 import com.expedia.graphql.generator.extensions.wrapInNonNull
 import com.expedia.graphql.generator.state.KGraphQLType
 import com.expedia.graphql.generator.state.TypesCacheKey
@@ -48,8 +48,8 @@ internal open class TypeBuilder constructor(val generator: SchemaGenerator) {
         kClass.isEnum() -> @Suppress("UNCHECKED_CAST") (generator.enumType(kClass as KClass<Enum<*>>))
         kClass.isArray() -> generator.arrayType(type, inputType)
         kClass.isList() -> generator.listType(type, inputType)
-        kClass.isGraphQLUnion() -> generator.unionType(kClass)
-        kClass.isGraphQLInterface() -> generator.interfaceType(kClass)
+        kClass.isUnion() -> generator.unionType(kClass)
+        kClass.isInterface() -> generator.interfaceType(kClass)
         inputType -> generator.inputObjectType(kClass)
         else -> generator.objectType(kClass)
     }

--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/directiveExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/directiveExtensions.kt
@@ -1,7 +1,6 @@
 package com.expedia.graphql.generator.extensions
 
 import com.expedia.graphql.annotations.GraphQLDirective
-import com.expedia.graphql.exceptions.CouldNotGetNameOfAnnotationException
 import com.expedia.graphql.generator.SchemaGenerator
 import com.google.common.base.CaseFormat
 import graphql.schema.GraphQLArgument
@@ -21,14 +20,12 @@ private fun Annotation.getDirectiveInfo(): DirectiveInfo? {
         .firstOrNull()
 }
 
-@Throws(CouldNotGetNameOfAnnotationException::class)
 private fun DirectiveInfo.getGraphQLDirective(generator: SchemaGenerator): graphql.schema.GraphQLDirective {
     val directiveClass = this.directive.annotationClass
-    val name: String = this.effectiveName ?: throw CouldNotGetNameOfAnnotationException(directiveClass)
 
     @Suppress("Detekt.SpreadOperator")
     val builder = graphql.schema.GraphQLDirective.newDirective()
-        .name(name)
+        .name(this.effectiveName)
         .validLocations(*this.directiveAnnotation.locations)
         .description(this.directiveAnnotation.description)
 
@@ -52,8 +49,8 @@ private fun DirectiveInfo.getGraphQLDirective(generator: SchemaGenerator): graph
 private fun String.normalizeDirectiveName() = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, this)
 
 private data class DirectiveInfo(val directive: Annotation, val directiveAnnotation: GraphQLDirective) {
-    val effectiveName: String? = when {
+    val effectiveName: String = when {
         directiveAnnotation.name.isNotEmpty() -> directiveAnnotation.name
-        else -> directive.annotationClass.simpleName?.normalizeDirectiveName()
+        else -> directive.annotationClass.getSimpleName().normalizeDirectiveName()
     }
 }

--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/kClassExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/kClassExtensions.kt
@@ -42,3 +42,5 @@ internal fun KClass<*>.isArray(): Boolean = this.java.isArray
 @Throws(CouldNotGetNameOfKClassException::class)
 internal fun KClass<*>.getSimpleName(): String =
     this.simpleName ?: throw CouldNotGetNameOfKClassException(this)
+
+internal fun KClass<*>.getInputClassName(): String = "${this.getSimpleName()}Input"

--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/kClassExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/kClassExtensions.kt
@@ -1,8 +1,9 @@
 package com.expedia.graphql.generator.extensions
 
-import com.expedia.graphql.hooks.SchemaGeneratorHooks
+import com.expedia.graphql.exceptions.CouldNotGetNameOfKClassException
 import com.expedia.graphql.generator.functionFilters
 import com.expedia.graphql.generator.propertyFilters
+import com.expedia.graphql.hooks.SchemaGeneratorHooks
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
@@ -27,13 +28,17 @@ internal fun KClass<*>.findConstructorParamter(name: String): KParameter? =
         ?.parameters
         ?.find { it.name == name }
 
-internal fun KClass<*>.isGraphQLInterface(): Boolean = this.java.isInterface
+internal fun KClass<*>.isInterface(): Boolean = this.java.isInterface
 
-internal fun KClass<*>.isGraphQLUnion(): Boolean =
-    this.isGraphQLInterface() && this.declaredMemberProperties.isEmpty() && this.declaredMemberFunctions.isEmpty()
+internal fun KClass<*>.isUnion(): Boolean =
+    this.isInterface() && this.declaredMemberProperties.isEmpty() && this.declaredMemberFunctions.isEmpty()
 
 internal fun KClass<*>.isEnum(): Boolean = this.isSubclassOf(Enum::class)
 
 internal fun KClass<*>.isList(): Boolean = this.isSubclassOf(List::class)
 
 internal fun KClass<*>.isArray(): Boolean = this.java.isArray
+
+@Throws(CouldNotGetNameOfKClassException::class)
+internal fun KClass<*>.getSimpleName(): String =
+    this.simpleName ?: throw CouldNotGetNameOfKClassException(this)

--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/kParameterExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/kParameterExtensions.kt
@@ -1,6 +1,7 @@
 package com.expedia.graphql.generator.extensions
 
 import com.expedia.graphql.annotations.GraphQLContext
+import com.expedia.graphql.exceptions.CouldNotGetNameOfKParameterException
 import com.expedia.graphql.exceptions.InvalidInputFieldTypeException
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.findAnnotation
@@ -8,7 +9,11 @@ import kotlin.reflect.jvm.jvmErasure
 
 @Throws(InvalidInputFieldTypeException::class)
 internal fun KParameter.throwIfUnathorizedInterface() {
-    if (this.type.jvmErasure.java.isInterface) throw InvalidInputFieldTypeException()
+    if (this.type.jvmErasure.isInterface()) throw InvalidInputFieldTypeException()
 }
 
 internal fun KParameter.isGraphQLContext() = this.findAnnotation<GraphQLContext>() != null
+
+@Throws(CouldNotGetNameOfKParameterException::class)
+internal fun KParameter.getName(): String =
+    this.name ?: throw CouldNotGetNameOfKParameterException(this)

--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/kTypeExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/kTypeExtensions.kt
@@ -1,7 +1,7 @@
 package com.expedia.graphql.generator.extensions
 
 import com.expedia.graphql.exceptions.CouldNotCastToKClassException
-import com.expedia.graphql.exceptions.CouldNotGetJvmNameOfKTypeException
+import com.expedia.graphql.exceptions.CouldNotGetNameOfKTypeException
 import com.expedia.graphql.exceptions.InvalidListTypeException
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -30,6 +30,9 @@ internal fun KType.getArrayType(): KType {
     }
 }
 
-@Throws(CouldNotGetJvmNameOfKTypeException::class)
-internal fun KType.getJvmErasureName(): String =
-    this.jvmErasure.simpleName ?: throw CouldNotGetJvmNameOfKTypeException(this)
+@Throws(CouldNotGetNameOfKTypeException::class)
+internal fun KType.getSimpleName(): String =
+    this.jvmErasure.simpleName ?: throw CouldNotGetNameOfKTypeException(this)
+
+internal val KType.qualifiedName: String
+    get() = this.jvmErasure.qualifiedName ?: ""

--- a/src/main/kotlin/com/expedia/graphql/generator/state/TypesCacheKey.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/state/TypesCacheKey.kt
@@ -1,0 +1,5 @@
+package com.expedia.graphql.generator.state
+
+import kotlin.reflect.KType
+
+internal data class TypesCacheKey(val type: KType, val inputType: Boolean)

--- a/src/main/kotlin/com/expedia/graphql/generator/types/EnumTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/EnumTypeBuilder.kt
@@ -1,9 +1,10 @@
 package com.expedia.graphql.generator.types
 
-import com.expedia.graphql.generator.extensions.getDeprecationReason
-import com.expedia.graphql.generator.extensions.getGraphQLDescription
 import com.expedia.graphql.generator.SchemaGenerator
 import com.expedia.graphql.generator.TypeBuilder
+import com.expedia.graphql.generator.extensions.getDeprecationReason
+import com.expedia.graphql.generator.extensions.getGraphQLDescription
+import com.expedia.graphql.generator.extensions.getSimpleName
 import graphql.schema.GraphQLEnumType
 import graphql.schema.GraphQLEnumValueDefinition
 import kotlin.reflect.KClass
@@ -12,7 +13,7 @@ internal class EnumTypeBuilder(generator: SchemaGenerator) : TypeBuilder(generat
     internal fun enumType(kClass: KClass<out Enum<*>>): GraphQLEnumType {
         val enumBuilder = GraphQLEnumType.newEnum()
 
-        enumBuilder.name(kClass.simpleName)
+        enumBuilder.name(kClass.getSimpleName())
         enumBuilder.description(kClass.getGraphQLDescription())
 
         kClass.java.enumConstants.forEach {

--- a/src/main/kotlin/com/expedia/graphql/generator/types/FunctionTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/FunctionTypeBuilder.kt
@@ -46,8 +46,6 @@ internal class FunctionTypeBuilder(generator: SchemaGenerator) : TypeBuilder(gen
 
             val name = it.getName()
 
-            // Kotlin 1.3 will support contracts, until then we need to force non-null
-            @Suppress("Detekt.UnsafeCallOnNullableType")
             args[name] = Parameter(it.type.javaType as Class<*>, it.annotations)
         }
 

--- a/src/main/kotlin/com/expedia/graphql/generator/types/FunctionTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/FunctionTypeBuilder.kt
@@ -2,14 +2,14 @@ package com.expedia.graphql.generator.types
 
 import com.expedia.graphql.KotlinDataFetcher
 import com.expedia.graphql.Parameter
-import com.expedia.graphql.exceptions.CouldNotGetNameOfArgumentException
+import com.expedia.graphql.generator.SchemaGenerator
+import com.expedia.graphql.generator.TypeBuilder
 import com.expedia.graphql.generator.extensions.directives
 import com.expedia.graphql.generator.extensions.getDeprecationReason
 import com.expedia.graphql.generator.extensions.getGraphQLDescription
+import com.expedia.graphql.generator.extensions.getName
 import com.expedia.graphql.generator.extensions.isGraphQLContext
 import com.expedia.graphql.generator.extensions.throwIfUnathorizedInterface
-import com.expedia.graphql.generator.SchemaGenerator
-import com.expedia.graphql.generator.TypeBuilder
 import graphql.schema.DataFetcher
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLFieldDefinition
@@ -23,7 +23,6 @@ import kotlin.reflect.jvm.javaType
 @Suppress("Detekt.UnsafeCast")
 internal class FunctionTypeBuilder(generator: SchemaGenerator) : TypeBuilder(generator) {
 
-    @Throws(CouldNotGetNameOfArgumentException::class)
     internal fun function(fn: KFunction<*>, target: Any? = null, abstract: Boolean = false): GraphQLFieldDefinition {
         val builder = GraphQLFieldDefinition.newFieldDefinition()
         builder.name(fn.name)
@@ -45,14 +44,11 @@ internal class FunctionTypeBuilder(generator: SchemaGenerator) : TypeBuilder(gen
                 builder.argument(argument(it))
             }
 
-            val name = it.name
-            if (name.isNullOrBlank()) {
-                throw CouldNotGetNameOfArgumentException(it)
-            } else {
-                // Kotlin 1.3 will support contracts, until then we need to force non-null
-                @Suppress("Detekt.UnsafeCallOnNullableType")
-                args[name] = Parameter(it.type.javaType as Class<*>, it.annotations)
-            }
+            val name = it.getName()
+
+            // Kotlin 1.3 will support contracts, until then we need to force non-null
+            @Suppress("Detekt.UnsafeCallOnNullableType")
+            args[name] = Parameter(it.type.javaType as Class<*>, it.annotations)
         }
 
         if (!abstract) {

--- a/src/main/kotlin/com/expedia/graphql/generator/types/InputObjectTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/InputObjectTypeBuilder.kt
@@ -6,6 +6,7 @@ import com.expedia.graphql.generator.extensions.getGraphQLDescription
 import com.expedia.graphql.generator.extensions.isPropertyGraphQLID
 import com.expedia.graphql.generator.SchemaGenerator
 import com.expedia.graphql.generator.TypeBuilder
+import com.expedia.graphql.generator.extensions.getSimpleName
 import graphql.schema.GraphQLInputObjectField
 import graphql.schema.GraphQLInputObjectType
 import graphql.schema.GraphQLInputType
@@ -37,5 +38,5 @@ internal class InputObjectTypeBuilder(generator: SchemaGenerator) : TypeBuilder(
         return builder.build()
     }
 
-    private fun getInputClassName(klass: KClass<*>): String? = klass.simpleName?.let { "${it}Input" }
+    private fun getInputClassName(klass: KClass<*>): String = klass.getSimpleName().let { "${it}Input" }
 }

--- a/src/main/kotlin/com/expedia/graphql/generator/types/InputObjectTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/InputObjectTypeBuilder.kt
@@ -1,12 +1,12 @@
 package com.expedia.graphql.generator.types
 
-import com.expedia.graphql.generator.extensions.getPropertyDescription
-import com.expedia.graphql.generator.extensions.getValidProperties
-import com.expedia.graphql.generator.extensions.getGraphQLDescription
-import com.expedia.graphql.generator.extensions.isPropertyGraphQLID
 import com.expedia.graphql.generator.SchemaGenerator
 import com.expedia.graphql.generator.TypeBuilder
-import com.expedia.graphql.generator.extensions.getSimpleName
+import com.expedia.graphql.generator.extensions.getGraphQLDescription
+import com.expedia.graphql.generator.extensions.getInputClassName
+import com.expedia.graphql.generator.extensions.getPropertyDescription
+import com.expedia.graphql.generator.extensions.getValidProperties
+import com.expedia.graphql.generator.extensions.isPropertyGraphQLID
 import graphql.schema.GraphQLInputObjectField
 import graphql.schema.GraphQLInputObjectType
 import graphql.schema.GraphQLInputType
@@ -16,12 +16,11 @@ import kotlin.reflect.KProperty
 internal class InputObjectTypeBuilder(generator: SchemaGenerator) : TypeBuilder(generator) {
     internal fun inputObjectType(kClass: KClass<*>): GraphQLInputObjectType {
         val builder = GraphQLInputObjectType.newInputObject()
-        val name = getInputClassName(kClass)
 
-        builder.name(name)
+        builder.name(kClass.getInputClassName())
         builder.description(kClass.getGraphQLDescription())
 
-        // It does not make sense to run functions against the input types so we only process data fields
+        // It does not make sense to run functions against the input types so we only process the properties
         kClass.getValidProperties(config.hooks)
             .forEach { builder.field(inputProperty(it, kClass)) }
 
@@ -37,6 +36,4 @@ internal class InputObjectTypeBuilder(generator: SchemaGenerator) : TypeBuilder(
 
         return builder.build()
     }
-
-    private fun getInputClassName(klass: KClass<*>): String = klass.getSimpleName().let { "${it}Input" }
 }

--- a/src/main/kotlin/com/expedia/graphql/generator/types/InterfaceTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/InterfaceTypeBuilder.kt
@@ -5,6 +5,7 @@ import com.expedia.graphql.generator.extensions.getValidProperties
 import com.expedia.graphql.generator.extensions.getGraphQLDescription
 import com.expedia.graphql.generator.SchemaGenerator
 import com.expedia.graphql.generator.TypeBuilder
+import com.expedia.graphql.generator.extensions.getSimpleName
 import graphql.TypeResolutionEnvironment
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLType
@@ -16,7 +17,7 @@ internal class InterfaceTypeBuilder(generator: SchemaGenerator) : TypeBuilder(ge
         return state.cache.buildIfNotUnderConstruction(kClass) { _ ->
             val builder = GraphQLInterfaceType.newInterface()
 
-            builder.name(kClass.simpleName)
+            builder.name(kClass.getSimpleName())
             builder.description(kClass.getGraphQLDescription())
 
             kClass.getValidProperties(config.hooks)

--- a/src/main/kotlin/com/expedia/graphql/generator/types/ObjectTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/ObjectTypeBuilder.kt
@@ -1,13 +1,14 @@
 package com.expedia.graphql.generator.types
 
-import com.expedia.graphql.generator.extensions.directives
-import com.expedia.graphql.generator.extensions.getGraphQLDescription
-import com.expedia.graphql.generator.extensions.getValidFunctions
-import com.expedia.graphql.generator.extensions.getValidProperties
-import com.expedia.graphql.generator.extensions.isGraphQLInterface
-import com.expedia.graphql.generator.extensions.isGraphQLUnion
 import com.expedia.graphql.generator.SchemaGenerator
 import com.expedia.graphql.generator.TypeBuilder
+import com.expedia.graphql.generator.extensions.directives
+import com.expedia.graphql.generator.extensions.getGraphQLDescription
+import com.expedia.graphql.generator.extensions.getSimpleName
+import com.expedia.graphql.generator.extensions.getValidFunctions
+import com.expedia.graphql.generator.extensions.getValidProperties
+import com.expedia.graphql.generator.extensions.isInterface
+import com.expedia.graphql.generator.extensions.isUnion
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLType
@@ -21,7 +22,7 @@ internal class ObjectTypeBuilder(generator: SchemaGenerator) : TypeBuilder(gener
         return state.cache.buildIfNotUnderConstruction(kClass) { _ ->
             val builder = GraphQLObjectType.newObject()
 
-            builder.name(kClass.simpleName)
+            builder.name(kClass.getSimpleName())
             builder.description(kClass.getGraphQLDescription())
 
             kClass.directives(generator).forEach {
@@ -34,7 +35,7 @@ internal class ObjectTypeBuilder(generator: SchemaGenerator) : TypeBuilder(gener
             } else {
                 kClass.superclasses
                     .asSequence()
-                    .filter { it.isGraphQLInterface() && !it.isGraphQLUnion() }
+                    .filter { it.isInterface() && !it.isUnion() }
                     .map { objectFromReflection(it.createType(), false) as? GraphQLInterfaceType }
                     .forEach { builder.withInterface(it) }
             }

--- a/src/main/kotlin/com/expedia/graphql/generator/types/UnionTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/UnionTypeBuilder.kt
@@ -1,10 +1,11 @@
 package com.expedia.graphql.generator.types
 
-import com.expedia.graphql.generator.extensions.getGraphQLDescription
 import com.expedia.graphql.generator.SchemaGenerator
 import com.expedia.graphql.generator.TypeBuilder
-import com.expedia.graphql.generator.state.TypesCacheKey
+import com.expedia.graphql.generator.extensions.getGraphQLDescription
+import com.expedia.graphql.generator.extensions.getSimpleName
 import com.expedia.graphql.generator.state.KGraphQLType
+import com.expedia.graphql.generator.state.TypesCacheKey
 import graphql.TypeResolutionEnvironment
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLType
@@ -18,7 +19,7 @@ internal class UnionTypeBuilder(generator: SchemaGenerator) : TypeBuilder(genera
         return state.cache.buildIfNotUnderConstruction(kClass) { _ ->
             val builder = GraphQLUnionType.newUnionType()
 
-            builder.name(kClass.simpleName)
+            builder.name(kClass.getSimpleName())
             builder.description(kClass.getGraphQLDescription())
             builder.typeResolver { env: TypeResolutionEnvironment -> env.schema.getObjectType(env.getObject<Any>().javaClass.simpleName) }
 

--- a/src/test/kotlin/com/expedia/graphql/extensions/DeepNameKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/extensions/DeepNameKtTest.kt
@@ -1,0 +1,45 @@
+package com.expedia.graphql.extensions
+
+import graphql.schema.GraphQLList
+import graphql.schema.GraphQLNonNull
+import graphql.schema.GraphQLType
+import graphql.schema.GraphQLTypeVisitor
+import graphql.util.TraversalControl
+import graphql.util.TraverserContext
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+internal class DeepNameKtTest {
+
+    private class BasicType : GraphQLType {
+        override fun getName() = "BasicType"
+
+        override fun accept(context: TraverserContext<GraphQLType>, visitor: GraphQLTypeVisitor): TraversalControl =
+            context.thisNode().accept(context, visitor)
+    }
+
+    private val basicType = BasicType()
+
+    @Test
+    fun `deepname of basic type`() {
+        assertEquals(expected = "BasicType", actual = basicType.deepName)
+    }
+
+    @Test
+    fun `deepname of list`() {
+        val list = GraphQLList(basicType)
+        assertEquals(expected = "[BasicType]", actual = list.deepName)
+    }
+
+    @Test
+    fun `deepname of non null`() {
+        val nonNull = GraphQLNonNull(basicType)
+        assertEquals(expected = "BasicType!", actual = nonNull.deepName)
+    }
+
+    @Test
+    fun `deepname of non null list of non nulls`() {
+        val complicated = GraphQLNonNull(GraphQLList(GraphQLNonNull(basicType)))
+        assertEquals(expected = "[BasicType!]!", actual = complicated.deepName)
+    }
+}

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/GraphQLTypeExtensionsTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/GraphQLTypeExtensionsTest.kt
@@ -1,8 +1,6 @@
 package com.expedia.graphql.generator.extensions
 
 import com.expedia.graphql.exceptions.NestingNonNullTypeException
-import com.expedia.graphql.extensions.deepName
-import graphql.schema.GraphQLList
 import graphql.schema.GraphQLNonNull
 import graphql.schema.GraphQLType
 import graphql.schema.GraphQLTypeVisitor
@@ -26,29 +24,6 @@ internal class GraphQLTypeExtensionsTest {
     }
 
     private val basicType = BasicType()
-
-    @Test
-    fun `deepname of basic type`() {
-        assertEquals(expected = "BasicType", actual = basicType.deepName)
-    }
-
-    @Test
-    fun `deepname of list`() {
-        val list = GraphQLList(basicType)
-        assertEquals(expected = "[BasicType]", actual = list.deepName)
-    }
-
-    @Test
-    fun `deepname of non null`() {
-        val nonNull = GraphQLNonNull(basicType)
-        assertEquals(expected = "BasicType!", actual = nonNull.deepName)
-    }
-
-    @Test
-    fun `deepname of non null list of non nulls`() {
-        val complicated = GraphQLNonNull(GraphQLList(GraphQLNonNull(basicType)))
-        assertEquals(expected = "[BasicType!]!", actual = complicated.deepName)
-    }
 
     @Test
     fun `wrapInNonNull twice throws exception`() {

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/KClassExtensionsTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/KClassExtensionsTest.kt
@@ -134,4 +134,9 @@ internal class KClassExtensionsTest {
             object { }::class.getSimpleName()
         }
     }
+
+    @Test
+    fun `test input class name`() {
+        assertEquals("MyTestClassInput", MyTestClass::class.getInputClassName())
+    }
 }

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/KClassExtensionsTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/KClassExtensionsTest.kt
@@ -1,11 +1,13 @@
 package com.expedia.graphql.generator.extensions
 
+import com.expedia.graphql.exceptions.CouldNotGetNameOfKClassException
 import com.expedia.graphql.hooks.NoopSchemaGeneratorHooks
 import com.expedia.graphql.hooks.SchemaGeneratorHooks
 import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -114,14 +116,22 @@ internal class KClassExtensionsTest {
 
     @Test
     fun `test graphql interface extension`() {
-        assertTrue(TestInterface::class.isGraphQLInterface())
-        assertFalse(MyTestClass::class.isGraphQLInterface())
+        assertTrue(TestInterface::class.isInterface())
+        assertFalse(MyTestClass::class.isInterface())
     }
 
     @Test
     fun `test graphql union extension`() {
-        assertTrue(TestInterface::class.isGraphQLUnion())
-        assertFalse(InvalidPropertyUnionInterface::class.isGraphQLUnion())
-        assertFalse(InvalidFunctionUnionInterface::class.isGraphQLUnion())
+        assertTrue(TestInterface::class.isUnion())
+        assertFalse(InvalidPropertyUnionInterface::class.isUnion())
+        assertFalse(InvalidFunctionUnionInterface::class.isUnion())
+    }
+
+    @Test
+    fun `test class simple name`() {
+        assertEquals("MyTestClass", MyTestClass::class.getSimpleName())
+        assertFailsWith(CouldNotGetNameOfKClassException::class) {
+            object { }::class.getSimpleName()
+        }
     }
 }

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/KParameterExtensionsKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/KParameterExtensionsKtTest.kt
@@ -1,0 +1,30 @@
+package com.expedia.graphql.generator.extensions
+
+import com.expedia.graphql.exceptions.CouldNotGetNameOfKParameterException
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KParameter
+import kotlin.reflect.full.primaryConstructor
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+internal class KParameterExtensionsKtTest {
+
+    internal data class MyClass(val foo: String)
+
+    @Test
+    fun getName() {
+        val param = MyClass::class.primaryConstructor?.parameters?.first()
+        assertEquals(expected = "foo", actual = param?.getName())
+    }
+
+    @Test
+    fun getNameException() {
+        val mockParam: KParameter = mockk()
+        every { mockParam.name } returns null
+        assertFailsWith(CouldNotGetNameOfKParameterException::class) {
+            mockParam.getName()
+        }
+    }
+}

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/KTypeExtensionsKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/KTypeExtensionsKtTest.kt
@@ -1,6 +1,7 @@
 package com.expedia.graphql.generator.extensions
 
 import com.expedia.graphql.exceptions.CouldNotCastToKClassException
+import com.expedia.graphql.exceptions.CouldNotGetNameOfKTypeException
 import com.expedia.graphql.exceptions.InvalidListTypeException
 import io.mockk.every
 import io.mockk.mockk
@@ -59,7 +60,14 @@ internal class KTypeExtensionsKtTest {
     }
 
     @Test
-    fun getJvmErasureName() {
-        assertEquals("MyClass", MyClass::class.starProjectedType.getJvmErasureName())
+    fun getSimpleName() {
+        assertEquals("MyClass", MyClass::class.starProjectedType.getSimpleName())
+    }
+
+    @Test
+    fun getSimpleNameException() {
+        assertFailsWith(CouldNotGetNameOfKTypeException::class) {
+            object { }::class.starProjectedType.getSimpleName()
+        }
     }
 }


### PR DESCRIPTION
Pull out extension method for `simpleName` and `name` that return a non-nullable string and throw exceptions if it is null