### PR TITLE
feat: rename TopLevelObject

### DIFF
--- a/example/src/main/kotlin/com.expedia.graphql.sample/Application.kt
+++ b/example/src/main/kotlin/com.expedia.graphql.sample/Application.kt
@@ -1,7 +1,7 @@
 package com.expedia.graphql.sample
 
 import com.expedia.graphql.SchemaGeneratorConfig
-import com.expedia.graphql.TopLevelObjectDef
+import com.expedia.graphql.TopLevelObject
 import com.expedia.graphql.DirectiveWiringHelper
 import com.expedia.graphql.sample.context.MyGraphQLContextBuilder
 import com.expedia.graphql.sample.dataFetchers.SpringDataFetcherFactory
@@ -55,7 +55,7 @@ class Application {
             schemaConfig: SchemaGeneratorConfig
     ): GraphQLSchema {
         fun List<Any>.toTopLevelObjectDefs() = this.map {
-            TopLevelObjectDef(it)
+            TopLevelObject(it)
         }
 
         val schema = toSchema(

--- a/src/main/kotlin/com/expedia/graphql/TopLevelObject.kt
+++ b/src/main/kotlin/com/expedia/graphql/TopLevelObject.kt
@@ -7,6 +7,6 @@ import kotlin.reflect.KClass
  * class to be used for reflection.
  *
  * @param obj The target object (or proxy to target object)
- * @param klazz Optional class of the target (or the proxied object)
+ * @param kClass Optional KClass of the target (or the proxied object)
  */
-data class TopLevelObjectDef(val obj: Any, val klazz: KClass<*> = obj::class)
+data class TopLevelObject(val obj: Any, val kClass: KClass<*> = obj::class)

--- a/src/main/kotlin/com/expedia/graphql/generator/SchemaGenerator.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/SchemaGenerator.kt
@@ -1,7 +1,7 @@
 package com.expedia.graphql.generator
 
 import com.expedia.graphql.SchemaGeneratorConfig
-import com.expedia.graphql.TopLevelObjectDef
+import com.expedia.graphql.TopLevelObject
 import com.expedia.graphql.generator.extensions.getValidFunctions
 import com.expedia.graphql.generator.state.SchemaGeneratorState
 import com.expedia.graphql.generator.types.DirectiveTypeBuilder
@@ -25,8 +25,8 @@ import kotlin.reflect.KType
 
 @Suppress("Detekt.TooManyFunctions")
 internal class SchemaGenerator(
-    private val queries: List<TopLevelObjectDef>,
-    private val mutations: List<TopLevelObjectDef>,
+    private val queries: List<TopLevelObject>,
+    private val mutations: List<TopLevelObject>,
     internal val config: SchemaGeneratorConfig
 ) {
 
@@ -66,7 +66,7 @@ internal class SchemaGenerator(
         queryBuilder.name(config.topLevelQueryName)
 
         for (query in queries) {
-            query.klazz.getValidFunctions(config.hooks)
+            query.kClass.getValidFunctions(config.hooks)
                 .forEach {
                     val function = function(it, query.obj)
                     val functionFromHook = config.hooks.didGenerateQueryType(it, function)
@@ -83,7 +83,7 @@ internal class SchemaGenerator(
             mutationBuilder.name(config.topLevelMutationName)
 
             for (mutation in mutations) {
-                mutation.klazz.getValidFunctions(config.hooks)
+                mutation.kClass.getValidFunctions(config.hooks)
                     .forEach {
                         val function = function(it, mutation.obj)
                         val functionFromHook = config.hooks.didGenerateMutationType(it, function)

--- a/src/main/kotlin/com/expedia/graphql/toSchema.kt
+++ b/src/main/kotlin/com/expedia/graphql/toSchema.kt
@@ -8,14 +8,14 @@ import graphql.schema.GraphQLSchema
 /**
  * Entry point to generate a graphql schema using reflection on the passed objects.
  *
- * @param queries List of [TopLevelObjectDef] objects to use for GraphQL queries
- * @param mutations List of [TopLevelObjectDef] objects to use for GraphQL mutations
+ * @param queries List of [TopLevelObject] objects to use for GraphQL queries
+ * @param mutations List of [TopLevelObject] objects to use for GraphQL mutations
  * @param config Schema generation configuration
  */
 @Throws(GraphQLException::class)
 fun toSchema(
-    queries: List<TopLevelObjectDef>,
-    mutations: List<TopLevelObjectDef> = emptyList(),
+    queries: List<TopLevelObject>,
+    mutations: List<TopLevelObject> = emptyList(),
     config: SchemaGeneratorConfig
 ): GraphQLSchema {
     if (queries.isEmpty()) {

--- a/src/test/kotlin/com/expedia/graphql/ToSchemaKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/ToSchemaKtTest.kt
@@ -10,13 +10,13 @@ internal class ToSchemaKtTest {
 
     @Test
     fun `valid schema`() {
-        val queries = listOf(TopLevelObjectDef(TestClass()))
+        val queries = listOf(TopLevelObject(TestClass()))
         toSchema(queries = queries, config = testSchemaConfig)
     }
 
     @Test
     fun `empty queries and mutations`() {
-        val mutations = listOf(TopLevelObjectDef(TestClass()))
+        val mutations = listOf(TopLevelObject(TestClass()))
         assertFailsWith(InvalidSchemaException::class) {
             toSchema(queries = emptyList(), mutations = mutations, config = testSchemaConfig)
         }

--- a/src/test/kotlin/com/expedia/graphql/TopLevelObjectTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/TopLevelObjectTest.kt
@@ -3,7 +3,7 @@ package com.expedia.graphql
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
-internal class TopLevelObjectDefTest {
+internal class TopLevelObjectTest {
 
     internal class TestClass
 
@@ -12,15 +12,15 @@ internal class TopLevelObjectDefTest {
     @Test
     fun `basic container`() {
         val obj = TestClass()
-        val top = TopLevelObjectDef(obj)
+        val top = TopLevelObject(obj)
         assertEquals(expected = obj, actual = top.obj)
-        assertEquals(expected = TestClass::class, actual = top.klazz)
+        assertEquals(expected = TestClass::class, actual = top.kClass)
     }
 
     @Test
     fun `custom class`() {
-        val top = TopLevelObjectDef(TestObject, TestClass::class)
+        val top = TopLevelObject(TestObject, TestClass::class)
         assertEquals(expected = TestObject, actual = top.obj)
-        assertEquals(expected = TestClass::class, actual = top.klazz)
+        assertEquals(expected = TestClass::class, actual = top.kClass)
     }
 }

--- a/src/test/kotlin/com/expedia/graphql/dataFetchers/CustomDataFetcherTests.kt
+++ b/src/test/kotlin/com/expedia/graphql/dataFetchers/CustomDataFetcherTests.kt
@@ -1,6 +1,6 @@
 package com.expedia.graphql.dataFetchers
 
-import com.expedia.graphql.TopLevelObjectDef
+import com.expedia.graphql.TopLevelObject
 import com.expedia.graphql.SchemaGeneratorConfig
 import com.expedia.graphql.extensions.deepName
 import com.expedia.graphql.toSchema
@@ -16,7 +16,7 @@ class CustomDataFetcherTests {
     @Test
     fun `Custom DataFetcher can be used on functions`() {
         val config = SchemaGeneratorConfig(supportedPackages = listOf("com.expedia"), dataFetcherFactory = PetDataFetcherFactory())
-        val schema = toSchema(listOf(TopLevelObjectDef(AnimalQuery())), config = config)
+        val schema = toSchema(listOf(TopLevelObject(AnimalQuery())), config = config)
 
         val animalType = schema.getObjectType("Animal")
         assertEquals("AnimalDetails", animalType.getFieldDefinition("details").type.deepName)

--- a/src/test/kotlin/com/expedia/graphql/dataFetchers/DataFetchPredicateTests.kt
+++ b/src/test/kotlin/com/expedia/graphql/dataFetchers/DataFetchPredicateTests.kt
@@ -1,6 +1,6 @@
 package com.expedia.graphql.dataFetchers
 
-import com.expedia.graphql.TopLevelObjectDef
+import com.expedia.graphql.TopLevelObject
 import com.expedia.graphql.Parameter
 import com.expedia.graphql.exceptions.GraphQLKotlinException
 import com.expedia.graphql.getTestSchemaConfigWithHooks
@@ -20,7 +20,7 @@ class DataFetchPredicateTests {
     fun `A datafetcher execution is stopped if the predicate test is false`() {
         val config = getTestSchemaConfigWithHooks(PredicateHooks())
         val schema = toSchema(
-                listOf(TopLevelObjectDef(QueryWithValidations())),
+                listOf(TopLevelObject(QueryWithValidations())),
                 config = config
         )
         val graphQL = GraphQL.newGraphQL(schema).build()
@@ -37,7 +37,7 @@ class DataFetchPredicateTests {
     fun `A datafetcher execution is stopped if the predicate test is false with complex argument under test`() {
         val config = getTestSchemaConfigWithHooks(PredicateHooks())
         val schema = toSchema(
-                listOf(TopLevelObjectDef(QueryWithValidations())),
+                listOf(TopLevelObject(QueryWithValidations())),
                 config = config
         )
         val graphQL = GraphQL.newGraphQL(schema).build()

--- a/src/test/kotlin/com/expedia/graphql/generator/DirectiveTests.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/DirectiveTests.kt
@@ -1,6 +1,6 @@
 package com.expedia.graphql.generator
 
-import com.expedia.graphql.TopLevelObjectDef
+import com.expedia.graphql.TopLevelObject
 import com.expedia.graphql.annotations.GraphQLDirective
 import com.expedia.graphql.testSchemaConfig
 import com.expedia.graphql.toSchema
@@ -15,7 +15,7 @@ import kotlin.test.assertTrue
 class DirectiveTests {
     @Test
     fun `SchemaGenerator marks deprecated fields in the return objects`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(QueryWithDeprecatedFields())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig)
         val topLevelQuery = schema.getObjectType("TopLevelQuery")
         val query = topLevelQuery.getFieldDefinition("deprecatedFieldQuery")
         val result = (query.type as? GraphQLNonNull)?.wrappedType as? GraphQLObjectType
@@ -27,7 +27,7 @@ class DirectiveTests {
 
     @Test
     fun `SchemaGenerator marks deprecated queries and documents replacement`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(QueryWithDeprecatedFields())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig)
         val topLevelQuery = schema.getObjectType("TopLevelQuery")
         val query = topLevelQuery.getFieldDefinition("deprecatedQueryWithReplacement")
 
@@ -37,7 +37,7 @@ class DirectiveTests {
 
     @Test
     fun `SchemaGenerator marks deprecated queries`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(QueryWithDeprecatedFields())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig)
         val topLevelQuery = schema.getObjectType("TopLevelQuery")
         val query = topLevelQuery.getFieldDefinition("deprecatedQuery")
         assertTrue(query.isDeprecated)
@@ -46,7 +46,7 @@ class DirectiveTests {
 
     @Test
     fun `Default directive names are normalized`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(QueryObject())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(QueryObject())), config = testSchemaConfig)
 
         val query = schema.queryType.getFieldDefinition("query")
         assertNotNull(query)
@@ -55,7 +55,7 @@ class DirectiveTests {
 
     @Test
     fun `Custom directive names are not modified`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(QueryObject())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(QueryObject())), config = testSchemaConfig)
 
         val directive = assertNotNull(
                 (schema.getType("Location") as? GraphQLObjectType)

--- a/src/test/kotlin/com/expedia/graphql/generator/PolymorphicTests.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/PolymorphicTests.kt
@@ -1,6 +1,6 @@
 package com.expedia.graphql.generator
 
-import com.expedia.graphql.TopLevelObjectDef
+import com.expedia.graphql.TopLevelObject
 import com.expedia.graphql.exceptions.InvalidInputFieldTypeException
 import com.expedia.graphql.testSchemaConfig
 import com.expedia.graphql.toSchema
@@ -16,7 +16,7 @@ internal class PolymorphicTests {
 
     @Test
     fun `Schema generator creates union types from marked up interface`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(QueryWithUnion())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(QueryWithUnion())), config = testSchemaConfig)
 
         val graphqlType = schema.getType("BodyPart") as? GraphQLUnionType
         assertNotNull(graphqlType)
@@ -33,7 +33,7 @@ internal class PolymorphicTests {
 
     @Test
     fun `SchemaGenerator can expose an interface and its implementations`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(QueryWithInterface())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(QueryWithInterface())), config = testSchemaConfig)
 
         val interfaceType = schema.getType("AnInterface")
         assertNotNull(interfaceType)
@@ -47,20 +47,20 @@ internal class PolymorphicTests {
     @Test
     fun `Interfaces cannot be used as input field types`() {
         assertThrows(InvalidInputFieldTypeException::class.java) {
-            toSchema(listOf(TopLevelObjectDef(QueryWithUnAuthorizedInterfaceArgument())), config = testSchemaConfig)
+            toSchema(listOf(TopLevelObject(QueryWithUnAuthorizedInterfaceArgument())), config = testSchemaConfig)
         }
     }
 
     @Test
     fun `Union cannot be used as input field types`() {
         assertThrows(InvalidInputFieldTypeException::class.java) {
-            toSchema(listOf(TopLevelObjectDef(QueryWithUnAuthorizedUnionArgument())), config = testSchemaConfig)
+            toSchema(listOf(TopLevelObject(QueryWithUnAuthorizedUnionArgument())), config = testSchemaConfig)
         }
     }
 
     @Test
     fun `Object types implementing union and interfaces are only created once`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(QueryWithInterfaceAnUnion())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(QueryWithInterfaceAnUnion())), config = testSchemaConfig)
 
         val carType = schema.getType("Car") as? GraphQLObjectType
         assertNotNull(carType)
@@ -74,7 +74,7 @@ internal class PolymorphicTests {
 
     @Test
     fun `Interfaces can declare properties of their own type`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(QueryWithRecursiveType())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(QueryWithRecursiveType())), config = testSchemaConfig)
 
         val personType = schema.getType("Person")
         assertNotNull(personType)

--- a/src/test/kotlin/com/expedia/graphql/generator/SchemaGeneratorAsyncTests.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/SchemaGeneratorAsyncTests.kt
@@ -1,6 +1,6 @@
 package com.expedia.graphql.generator
 
-import com.expedia.graphql.TopLevelObjectDef
+import com.expedia.graphql.TopLevelObject
 import com.expedia.graphql.getTestSchemaConfigWithHooks
 import com.expedia.graphql.hooks.SchemaGeneratorHooks
 import com.expedia.graphql.testSchemaConfig
@@ -27,7 +27,7 @@ class SchemaGeneratorAsyncTests {
 
     @Test
     fun `SchemaGenerator strips type argument from CompletableFuture to support async servlet`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(AsyncQuery())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(AsyncQuery())), config = testSchemaConfig)
         val returnTypeName =
             (schema.getObjectType("TopLevelQuery").getFieldDefinition("asynchronouslyDo").type as? GraphQLNonNull)?.wrappedType?.name
         assertEquals("Int", returnTypeName)
@@ -35,7 +35,7 @@ class SchemaGeneratorAsyncTests {
 
     @Test
     fun `SchemaGenerator strips type argument from RxJava2 Observable`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(RxJava2Query())), config = configWithRxJavaMonads)
+        val schema = toSchema(listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
         val returnTypeName =
             (schema.getObjectType("TopLevelQuery").getFieldDefinition("asynchronouslyDo").type as? GraphQLNonNull)?.wrappedType?.name
         assertEquals("Int", returnTypeName)
@@ -43,7 +43,7 @@ class SchemaGeneratorAsyncTests {
 
     @Test
     fun `SchemaGenerator strips type argument from RxJava2 Single`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(RxJava2Query())), config = configWithRxJavaMonads)
+        val schema = toSchema(listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
         val returnTypeName =
             (schema.getObjectType("TopLevelQuery").getFieldDefinition("asynchronouslyDoSingle").type as? GraphQLNonNull)?.wrappedType?.name
         assertEquals("Int", returnTypeName)
@@ -51,7 +51,7 @@ class SchemaGeneratorAsyncTests {
 
     @Test
     fun `SchemaGenerator strips type argument from RxJava2 Maybe`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(RxJava2Query())), config = configWithRxJavaMonads)
+        val schema = toSchema(listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
         val returnTypeName =
             (schema.getObjectType("TopLevelQuery").getFieldDefinition("maybe").type as? GraphQLNonNull)?.wrappedType?.name
         assertEquals("Int", returnTypeName)

--- a/src/test/kotlin/com/expedia/graphql/generator/SchemaGeneratorTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/SchemaGeneratorTest.kt
@@ -1,6 +1,6 @@
 package com.expedia.graphql.generator
 
-import com.expedia.graphql.TopLevelObjectDef
+import com.expedia.graphql.TopLevelObject
 import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.annotations.GraphQLID
 import com.expedia.graphql.annotations.GraphQLIgnore
@@ -30,8 +30,8 @@ class SchemaGeneratorTest {
     @Test
     fun `SchemaGenerator generates a simple GraphQL schema`() {
         val schema = toSchema(
-            listOf(TopLevelObjectDef(QueryObject())),
-            listOf(TopLevelObjectDef(MutationObject())),
+            listOf(TopLevelObject(QueryObject())),
+            listOf(TopLevelObject(MutationObject())),
             config = testSchemaConfig
         )
         val graphQL = GraphQL.newGraphQL(schema).build()
@@ -44,7 +44,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `Schema generator exposes arrays of primitive types as function arguments`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(QueryWithArray())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(QueryWithArray())), config = testSchemaConfig)
         val firstArgumentType = schema.queryType.getFieldDefinition("sumOf").arguments[0].type.deepName
         assertEquals("[Int!]!", firstArgumentType)
 
@@ -57,7 +57,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `Schema generator exposes arrays of complex types as function arguments`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(QueryWithArray())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(QueryWithArray())), config = testSchemaConfig)
         val firstArgumentType = schema.queryType.getFieldDefinition("sumOfComplexArray").arguments[0].type.deepName
         assertEquals("[ComplexWrappingTypeInput!]!", firstArgumentType)
 
@@ -70,7 +70,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `SchemaGenerator ignores fields and functions with @Ignore`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(QueryWithIgnored())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(QueryWithIgnored())), config = testSchemaConfig)
 
         assertTrue(schema.queryType.fieldDefinitions.none {
             it.name == "ignoredFunction"
@@ -88,7 +88,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `SchemaGenerator generates a GraphQL schema with repeated types to test conflicts`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(QueryWithRepeatedTypes())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(QueryWithRepeatedTypes())), config = testSchemaConfig)
         val resultType = schema.getObjectType("Result")
         val topLevelQuery = schema.getObjectType("TopLevelQuery")
         assertEquals("Result!", topLevelQuery.getFieldDefinition("query").type.deepName)
@@ -101,7 +101,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `SchemaGenerator generates a GraphQL schema with mixed nullity`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(QueryWithNullableAndNonNullTypes())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(QueryWithNullableAndNonNullTypes())), config = testSchemaConfig)
         val resultType = schema.getObjectType("MixedNullityResult")
         val topLevelQuery = schema.getObjectType("TopLevelQuery")
         assertEquals("MixedNullityResult!", topLevelQuery.getFieldDefinition("query").type.deepName)
@@ -111,7 +111,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `SchemaGenerator generates a GraphQL schema where the input types differ from the output types`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(QueryWithInputObject())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(QueryWithInputObject())), config = testSchemaConfig)
         val topLevelQuery = schema.getObjectType("TopLevelQuery")
         assertEquals(
             "SomeObjectInput!",
@@ -122,7 +122,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `SchemaGenerator generates a GraphQL schema where the input and output enum is the same`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(QueryWithInputEnum())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(QueryWithInputEnum())), config = testSchemaConfig)
         val topLevelQuery = schema.getObjectType("TopLevelQuery")
         assertEquals("SomeEnum!", topLevelQuery.getFieldDefinition("query").getArgument("someEnum").type.deepName)
         assertEquals("SomeEnum!", topLevelQuery.getFieldDefinition("query").type.deepName)
@@ -131,8 +131,8 @@ class SchemaGeneratorTest {
     @Test
     fun `SchemaGenerator documents types annotated with @Description`() {
         val schema = toSchema(
-            listOf(TopLevelObjectDef(QueryObject())),
-            listOf(TopLevelObjectDef(MutationObject())),
+            listOf(TopLevelObject(QueryObject())),
+            listOf(TopLevelObject(MutationObject())),
             config = testSchemaConfig
         )
         val geo = schema.getObjectType("Geography")
@@ -142,8 +142,8 @@ class SchemaGeneratorTest {
     @Test
     fun `SchemaGenerator documents arguments annotated with @Description`() {
         val schema = toSchema(
-            listOf(TopLevelObjectDef(QueryObject())),
-            listOf(TopLevelObjectDef(MutationObject())),
+            listOf(TopLevelObject(QueryObject())),
+            listOf(TopLevelObject(MutationObject())),
             config = testSchemaConfig
         )
         val documentation = schema.queryType.fieldDefinitions.first().arguments.first().description
@@ -153,8 +153,8 @@ class SchemaGeneratorTest {
     @Test
     fun `SchemaGenerator documents properties annotated with @Description`() {
         val schema = toSchema(
-            listOf(TopLevelObjectDef(QueryObject())),
-            listOf(TopLevelObjectDef(MutationObject())),
+            listOf(TopLevelObject(QueryObject())),
+            listOf(TopLevelObject(MutationObject())),
             config = testSchemaConfig
         )
         val documentation = schema.queryType.fieldDefinitions.first().description
@@ -163,7 +163,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `SchemaGenerator can expose functions on result classes`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(QueryWithDataThatContainsFunction())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(QueryWithDataThatContainsFunction())), config = testSchemaConfig)
         val resultWithFunction = schema.getObjectType("ResultWithFunction")
         val repeatFieldDefinition = resultWithFunction.getFieldDefinition("repeat")
         assertEquals("repeat", repeatFieldDefinition.name)
@@ -174,7 +174,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `SchemaGenerator can execute functions on result classes`() {
-        val schema = toSchema(listOf(TopLevelObjectDef(QueryWithDataThatContainsFunction())), config = testSchemaConfig)
+        val schema = toSchema(listOf(TopLevelObject(QueryWithDataThatContainsFunction())), config = testSchemaConfig)
         val graphQL = GraphQL.newGraphQL(schema).build()
         val result = graphQL.execute("{ query(something: \"thing\") { repeat(n: 3) } }")
         val data: Map<String, Map<String, Any>> = result.getData()
@@ -185,7 +185,7 @@ class SchemaGeneratorTest {
     @Test
     fun `SchemaGenerator ignores private fields`() {
         val schema =
-            toSchema(listOf(TopLevelObjectDef(QueryWithPrivateParts())), config = testSchemaConfig)
+            toSchema(listOf(TopLevelObject(QueryWithPrivateParts())), config = testSchemaConfig)
         val topLevelQuery = schema.getObjectType("TopLevelQuery")
         val query = topLevelQuery.getFieldDefinition("query")
         val resultWithPrivateParts = query.type as? GraphQLObjectType
@@ -198,21 +198,21 @@ class SchemaGeneratorTest {
     @Test
     fun `SchemaGenerator throws when encountering java stdlib`() {
         assertFailsWith(RuntimeException::class) {
-            toSchema(listOf(TopLevelObjectDef(QueryWithJavaClass())), config = testSchemaConfig)
+            toSchema(listOf(TopLevelObject(QueryWithJavaClass())), config = testSchemaConfig)
         }
     }
 
     @Test
     fun `SchemaGenerator throws when encountering conflicting types`() {
         assertFailsWith(ConflictingTypesException::class) {
-            toSchema(queries = listOf(TopLevelObjectDef(QueryWithConflictingTypes())), config = testSchemaConfig)
+            toSchema(queries = listOf(TopLevelObject(QueryWithConflictingTypes())), config = testSchemaConfig)
         }
     }
 
     @Suppress("UNCHECKED_CAST")
     @Test
     fun `SchemaGenerator supports type references`() {
-        val schema = toSchema(queries = listOf(TopLevelObjectDef(QueryWithParentChildRelationship())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithParentChildRelationship())), config = testSchemaConfig)
 
         val graphQL = GraphQL.newGraphQL(schema).build()
         val result = graphQL.execute("{ query { name children { name } } }")
@@ -231,7 +231,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `SchemaGenerator support GraphQLID scalar`() {
-        val schema = toSchema(queries = listOf(TopLevelObjectDef(QueryWithId())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithId())), config = testSchemaConfig)
 
         val placeType = schema.getObjectType("PlaceOfIds")
         assertEquals(Scalars.GraphQLID, (placeType.getFieldDefinition("intId").type as? GraphQLNonNull)?.wrappedType)
@@ -243,7 +243,7 @@ class SchemaGeneratorTest {
     @Test
     fun `SchemaGenerator throws an exception for invalid GraphQLID`() {
         val exception = assertFailsWith(InvalidIdTypeException::class) {
-            toSchema(queries = listOf(TopLevelObjectDef(QueryWithInvalidId())), config = testSchemaConfig)
+            toSchema(queries = listOf(TopLevelObject(QueryWithInvalidId())), config = testSchemaConfig)
         }
 
         assertEquals("Person is not a valid ID type, only [kotlin.Int, kotlin.String, kotlin.Long, java.util.UUID] are accepted", exception.message)
@@ -251,7 +251,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `SchemaGenerator supports Scalar GraphQLID for input types`() {
-        val schema = toSchema(queries = listOf(TopLevelObjectDef(QueryObject())), mutations = listOf(TopLevelObjectDef(MutationWithId())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryObject())), mutations = listOf(TopLevelObject(MutationWithId())), config = testSchemaConfig)
 
         val furnitureType = schema.getObjectType("Furniture")
         val serialField = furnitureType.getFieldDefinition("serial").type as? GraphQLNonNull

--- a/src/test/kotlin/com/expedia/graphql/hooks/SchemaGeneratorHooksTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/hooks/SchemaGeneratorHooksTest.kt
@@ -1,6 +1,6 @@
 package com.expedia.graphql.hooks
 
-import com.expedia.graphql.TopLevelObjectDef
+import com.expedia.graphql.TopLevelObject
 import com.expedia.graphql.extensions.deepName
 import com.expedia.graphql.getTestSchemaConfigWithHooks
 import com.expedia.graphql.toSchema
@@ -37,7 +37,7 @@ class SchemaGeneratorHooksTest {
 
         val hooks = MockSchemaGeneratorHooks()
         val schema = toSchema(
-            listOf(TopLevelObjectDef(TestQuery())),
+            listOf(TopLevelObject(TestQuery())),
             config = getTestSchemaConfigWithHooks(hooks)
         )
         assertTrue(hooks.willBuildSchemaCalled)
@@ -56,7 +56,7 @@ class SchemaGeneratorHooksTest {
 
         val hooks = MockSchemaGeneratorHooks()
         val schema = toSchema(
-            listOf(TopLevelObjectDef(TestQuery())),
+            listOf(TopLevelObject(TestQuery())),
             config = getTestSchemaConfigWithHooks(hooks)
         )
         val topLevelQuery = schema.getObjectType("TopLevelQuery")
@@ -78,7 +78,7 @@ class SchemaGeneratorHooksTest {
 
         val hooks = MockSchemaGeneratorHooks()
         val schema = toSchema(
-            listOf(TopLevelObjectDef(TestQuery())),
+            listOf(TopLevelObject(TestQuery())),
             config = getTestSchemaConfigWithHooks(hooks)
         )
         assertTrue(hooks.calledFilterFunction)
@@ -99,7 +99,7 @@ class SchemaGeneratorHooksTest {
 
         val hooks = MockSchemaGeneratorHooks()
         val schema = toSchema(
-            listOf(TopLevelObjectDef(TestQuery())),
+            listOf(TopLevelObject(TestQuery())),
             config = getTestSchemaConfigWithHooks(hooks)
         )
         assertTrue(hooks.calledFilterFunction)
@@ -119,7 +119,7 @@ class SchemaGeneratorHooksTest {
 
         val hooks = MockSchemaGeneratorHooks()
         toSchema(
-            listOf(TopLevelObjectDef(TestQuery())),
+            listOf(TopLevelObject(TestQuery())),
             config = getTestSchemaConfigWithHooks(hooks)
         )
         assertEquals(SomeData::class.createType(), hooks.lastSeenType)
@@ -143,7 +143,7 @@ class SchemaGeneratorHooksTest {
 
         val hooks = MockSchemaGeneratorHooks()
         val schema = toSchema(
-            listOf(TopLevelObjectDef(TestQuery())),
+            listOf(TopLevelObject(TestQuery())),
             config = getTestSchemaConfigWithHooks(hooks)
         )
         val graphQL = GraphQL.newGraphQL(schema).build()
@@ -172,7 +172,7 @@ class SchemaGeneratorHooksTest {
 
         val hooks = MockSchemaGeneratorHooks()
         val schema = toSchema(
-            listOf(TopLevelObjectDef(TestQuery())),
+            listOf(TopLevelObject(TestQuery())),
             config = getTestSchemaConfigWithHooks(hooks)
         )
         val topLevelQuery = schema.getObjectType("TopLevelQuery")
@@ -198,8 +198,8 @@ class SchemaGeneratorHooksTest {
 
         val hooks = MockSchemaGeneratorHooks()
         val schema = toSchema(
-            queries = listOf(TopLevelObjectDef(TestQuery())),
-            mutations = listOf(TopLevelObjectDef(TestQuery())),
+            queries = listOf(TopLevelObject(TestQuery())),
+            mutations = listOf(TopLevelObject(TestQuery())),
             config = getTestSchemaConfigWithHooks(hooks)
         )
         val topLevelQuery = schema.getObjectType("TopLevelMutation")


### PR DESCRIPTION
Drop all short hands and clever names for explict types