### PR TITLE
fix: description of parameters

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/generator/SchemaGenerator.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/SchemaGenerator.kt
@@ -14,6 +14,7 @@ import com.expedia.graphql.generator.types.ObjectTypeBuilder
 import com.expedia.graphql.generator.types.PropertyTypeBuilder
 import com.expedia.graphql.generator.types.ScalarTypeBuilder
 import com.expedia.graphql.generator.types.UnionTypeBuilder
+import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLSchema
@@ -105,7 +106,7 @@ internal class SchemaGenerator(
         listTypeBuilder.listType(type, inputType)
 
     internal fun arrayType(type: KType, inputType: Boolean) =
-            listTypeBuilder.arrayType(type, inputType)
+        listTypeBuilder.arrayType(type, inputType)
 
     internal fun objectType(kClass: KClass<*>, interfaceType: GraphQLInterfaceType? = null) =
         objectTypeBuilder.objectType(kClass, interfaceType)
@@ -125,6 +126,9 @@ internal class SchemaGenerator(
     internal fun scalarType(type: KType, annotatedAsID: Boolean = false) =
         scalarTypeBuilder.scalarType(type, annotatedAsID)
 
-    internal fun directives(element: KAnnotatedElement) =
-        directiveTypeBuilder.directives(element)
+    internal fun directives(element: KAnnotatedElement): List<GraphQLDirective> {
+        val directives = directiveTypeBuilder.directives(element)
+        state.directives.addAll(directives)
+        return directives
+    }
 }

--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/kClassExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/kClassExtensions.kt
@@ -10,6 +10,7 @@ import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty
 import kotlin.reflect.full.declaredMemberFunctions
 import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.full.findParameterByName
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.primaryConstructor
 
@@ -24,9 +25,7 @@ internal fun KClass<*>.getValidFunctions(hooks: SchemaGeneratorHooks): List<KFun
         .filter { func -> functionFilters.all { it.invoke(func) } }
 
 internal fun KClass<*>.findConstructorParamter(name: String): KParameter? =
-    this.primaryConstructor
-        ?.parameters
-        ?.find { it.name == name }
+    this.primaryConstructor?.findParameterByName(name)
 
 internal fun KClass<*>.isInterface(): Boolean = this.java.isInterface
 

--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/kParameterExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/kParameterExtensions.kt
@@ -10,8 +10,6 @@ internal fun KParameter.isInterface() = this.type.jvmErasure.isInterface()
 
 internal fun KParameter.isGraphQLContext() = this.findAnnotation<GraphQLContext>() != null
 
-internal fun KParameter.getParamterGraphQLDescription() = this.getGraphQLDescription() ?: this.type.getKClass().getGraphQLDescription()
-
 @Throws(CouldNotGetNameOfKParameterException::class)
 internal fun KParameter.getName(): String =
     this.name ?: throw CouldNotGetNameOfKParameterException(this)

--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/kParameterExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/kParameterExtensions.kt
@@ -2,17 +2,15 @@ package com.expedia.graphql.generator.extensions
 
 import com.expedia.graphql.annotations.GraphQLContext
 import com.expedia.graphql.exceptions.CouldNotGetNameOfKParameterException
-import com.expedia.graphql.exceptions.InvalidInputFieldTypeException
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.jvm.jvmErasure
 
-@Throws(InvalidInputFieldTypeException::class)
-internal fun KParameter.throwIfUnathorizedInterface() {
-    if (this.type.jvmErasure.isInterface()) throw InvalidInputFieldTypeException()
-}
+internal fun KParameter.isInterface() = this.type.jvmErasure.isInterface()
 
 internal fun KParameter.isGraphQLContext() = this.findAnnotation<GraphQLContext>() != null
+
+internal fun KParameter.getParamterGraphQLDescription() = this.getGraphQLDescription() ?: this.type.getKClass().getGraphQLDescription()
 
 @Throws(CouldNotGetNameOfKParameterException::class)
 internal fun KParameter.getName(): String =

--- a/src/main/kotlin/com/expedia/graphql/generator/types/FunctionTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/FunctionTypeBuilder.kt
@@ -8,7 +8,6 @@ import com.expedia.graphql.generator.TypeBuilder
 import com.expedia.graphql.generator.extensions.getDeprecationReason
 import com.expedia.graphql.generator.extensions.getGraphQLDescription
 import com.expedia.graphql.generator.extensions.getName
-import com.expedia.graphql.generator.extensions.getParamterGraphQLDescription
 import com.expedia.graphql.generator.extensions.isGraphQLContext
 import com.expedia.graphql.generator.extensions.isInterface
 import graphql.schema.DataFetcher
@@ -70,7 +69,7 @@ internal class FunctionTypeBuilder(generator: SchemaGenerator) : TypeBuilder(gen
 
         val builder = GraphQLArgument.newArgument()
             .name(parameter.getName())
-            .description(parameter.getParamterGraphQLDescription())
+            .description(parameter.getGraphQLDescription())
             .type(graphQLTypeOf(parameter.type, true) as GraphQLInputType)
 
         generator.directives(parameter).forEach {

--- a/src/main/kotlin/com/expedia/graphql/generator/types/FunctionTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/FunctionTypeBuilder.kt
@@ -2,13 +2,15 @@ package com.expedia.graphql.generator.types
 
 import com.expedia.graphql.KotlinDataFetcher
 import com.expedia.graphql.Parameter
+import com.expedia.graphql.exceptions.InvalidInputFieldTypeException
 import com.expedia.graphql.generator.SchemaGenerator
 import com.expedia.graphql.generator.TypeBuilder
 import com.expedia.graphql.generator.extensions.getDeprecationReason
 import com.expedia.graphql.generator.extensions.getGraphQLDescription
 import com.expedia.graphql.generator.extensions.getName
+import com.expedia.graphql.generator.extensions.getParamterGraphQLDescription
 import com.expedia.graphql.generator.extensions.isGraphQLContext
-import com.expedia.graphql.generator.extensions.throwIfUnathorizedInterface
+import com.expedia.graphql.generator.extensions.isInterface
 import graphql.schema.DataFetcher
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLFieldDefinition
@@ -33,7 +35,6 @@ internal class FunctionTypeBuilder(generator: SchemaGenerator) : TypeBuilder(gen
 
         generator.directives(fn).forEach {
             builder.withDirective(it)
-            state.directives.add(it)
         }
 
         val args = mutableMapOf<String, Parameter>()
@@ -60,16 +61,20 @@ internal class FunctionTypeBuilder(generator: SchemaGenerator) : TypeBuilder(gen
         return config.hooks.onRewireGraphQLType(monadType, graphQLType) as GraphQLFieldDefinition
     }
 
+    @Throws(InvalidInputFieldTypeException::class)
     private fun argument(parameter: KParameter): GraphQLArgument {
-        parameter.throwIfUnathorizedInterface()
+
+        if (parameter.isInterface()) {
+            throw InvalidInputFieldTypeException()
+        }
+
         val builder = GraphQLArgument.newArgument()
-            .name(parameter.name)
-            .description(parameter.getGraphQLDescription() ?: parameter.type.getGraphQLDescription())
+            .name(parameter.getName())
+            .description(parameter.getParamterGraphQLDescription())
             .type(graphQLTypeOf(parameter.type, true) as GraphQLInputType)
 
         generator.directives(parameter).forEach {
             builder.withDirective(it)
-            state.directives.add(it)
         }
 
         return config.hooks.onRewireGraphQLType(parameter.type, builder.build()) as GraphQLArgument

--- a/src/main/kotlin/com/expedia/graphql/generator/types/ObjectTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/ObjectTypeBuilder.kt
@@ -26,7 +26,6 @@ internal class ObjectTypeBuilder(generator: SchemaGenerator) : TypeBuilder(gener
 
             generator.directives(kClass).forEach {
                 builder.withDirective(it)
-                state.directives.add(it)
             }
 
             if (interfaceType != null) {

--- a/src/main/kotlin/com/expedia/graphql/generator/types/PropertyTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/PropertyTypeBuilder.kt
@@ -25,7 +25,6 @@ internal class PropertyTypeBuilder(generator: SchemaGenerator) : TypeBuilder(gen
 
         generator.directives(prop).forEach {
             fieldBuilder.withDirective(it)
-            state.directives.add(it)
         }
 
         val field = if (config.dataFetcherFactory != null && prop.isLateinit) {

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/KParameterExtensionsKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/KParameterExtensionsKtTest.kt
@@ -1,22 +1,30 @@
 package com.expedia.graphql.generator.extensions
 
+import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.exceptions.CouldNotGetNameOfKParameterException
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import kotlin.reflect.KParameter
-import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.full.findParameterByName
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 internal class KParameterExtensionsKtTest {
 
+    @GraphQLDescription("class description")
     internal data class MyClass(val foo: String)
+
+    internal class Container {
+        internal fun classDescription(myClass: MyClass) = myClass
+
+        internal fun paramDescription(@GraphQLDescription("param description") myClass: MyClass) = myClass
+    }
 
     @Test
     fun getName() {
-        val param = MyClass::class.primaryConstructor?.parameters?.first()
-        assertEquals(expected = "foo", actual = param?.getName())
+        val param = Container::classDescription.findParameterByName("myClass")
+        assertEquals(expected = "myClass", actual = param?.getName())
     }
 
     @Test
@@ -26,5 +34,17 @@ internal class KParameterExtensionsKtTest {
         assertFailsWith(CouldNotGetNameOfKParameterException::class) {
             mockParam.getName()
         }
+    }
+
+    @Test
+    fun `class description`() {
+        val param = Container::classDescription.findParameterByName("myClass")
+        assertEquals(expected = "class description", actual = param?.getParamterGraphQLDescription())
+    }
+
+    @Test
+    fun `parameter description`() {
+        val param = Container::paramDescription.findParameterByName("myClass")
+        assertEquals(expected = "param description", actual = param?.getParamterGraphQLDescription())
     }
 }

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/KParameterExtensionsKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/KParameterExtensionsKtTest.kt
@@ -9,6 +9,7 @@ import kotlin.reflect.KParameter
 import kotlin.reflect.full.findParameterByName
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 
 internal class KParameterExtensionsKtTest {
 
@@ -16,14 +17,14 @@ internal class KParameterExtensionsKtTest {
     internal data class MyClass(val foo: String)
 
     internal class Container {
-        internal fun classDescription(myClass: MyClass) = myClass
+        internal fun noDescription(myClass: MyClass) = myClass
 
         internal fun paramDescription(@GraphQLDescription("param description") myClass: MyClass) = myClass
     }
 
     @Test
     fun getName() {
-        val param = Container::classDescription.findParameterByName("myClass")
+        val param = Container::noDescription.findParameterByName("myClass")
         assertEquals(expected = "myClass", actual = param?.getName())
     }
 
@@ -37,14 +38,14 @@ internal class KParameterExtensionsKtTest {
     }
 
     @Test
-    fun `class description`() {
-        val param = Container::classDescription.findParameterByName("myClass")
-        assertEquals(expected = "class description", actual = param?.getParamterGraphQLDescription())
+    fun `parameter description`() {
+        val param = Container::paramDescription.findParameterByName("myClass")
+        assertEquals(expected = "param description", actual = param?.getGraphQLDescription())
     }
 
     @Test
-    fun `parameter description`() {
-        val param = Container::paramDescription.findParameterByName("myClass")
-        assertEquals(expected = "param description", actual = param?.getParamterGraphQLDescription())
+    fun `no description`() {
+        val param = Container::noDescription.findParameterByName("myClass")
+        assertNull(param?.getGraphQLDescription())
     }
 }

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/KTypeExtensionsKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/KTypeExtensionsKtTest.kt
@@ -18,12 +18,20 @@ internal class KTypeExtensionsKtTest {
     internal class MyClass {
         fun listFun(list: List<String>) = list.joinToString(separator = ",") { it }
 
+        fun arrayFun(array: Array<String>) = array.joinToString(separator = ",") { it }
+
+        fun primitiveArrayFun(intArray: IntArray) = intArray.joinToString(separator = ",") { it.toString() }
+
         fun stringFun(string: String) = "hello $string"
     }
 
     @Test
     fun getTypeOfFirstArgument() {
         assertEquals(String::class.starProjectedType, MyClass::listFun.findParameterByName("list")?.type?.getTypeOfFirstArgument())
+
+        assertEquals(String::class.starProjectedType, MyClass::arrayFun.findParameterByName("array")?.type?.getTypeOfFirstArgument())
+
+        assertEquals(Int::class.starProjectedType, MyClass::primitiveArrayFun.findParameterByName("intArray")?.type?.getArrayType())
 
         assertFailsWith(InvalidListTypeException::class) {
             MyClass::stringFun.findParameterByName("string")?.type?.getTypeOfFirstArgument()

--- a/src/test/kotlin/com/expedia/graphql/generator/types/TypeTestHelper.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/TypeTestHelper.kt
@@ -51,7 +51,9 @@ internal open class TypeTestHelper {
 
         directiveTypeBuilder = spyk(DirectiveTypeBuilder(generator))
         every { generator.directives(any()) } answers {
-            directiveTypeBuilder!!.directives(it.invocation.args[0] as KAnnotatedElement)
+            val directives = directiveTypeBuilder!!.directives(it.invocation.args[0] as KAnnotatedElement)
+            state.directives.addAll(directives)
+            directives
         }
 
         beforeTest()


### PR DESCRIPTION
The graphql description was supposed to fall back to the description of the type of the argument if there was none. This was not working as we have to fall back to the KClass first.

Also I added more unit tests for getting the list type and array type and simplified the directives adding to state