### PR TITLE
refactor: create separate top level builders

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/generator/TypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/TypeBuilder.kt
@@ -13,7 +13,7 @@ import graphql.schema.GraphQLType
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 
-internal open class TypeBuilder constructor(val generator: SchemaGenerator) {
+internal open class TypeBuilder constructor(protected val generator: SchemaGenerator) {
     protected val state = generator.state
     protected val config = generator.config
     protected val subTypeMapper = generator.subTypeMapper

--- a/src/main/kotlin/com/expedia/graphql/generator/types/MutationTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/MutationTypeBuilder.kt
@@ -1,0 +1,31 @@
+package com.expedia.graphql.generator.types
+
+import com.expedia.graphql.TopLevelObject
+import com.expedia.graphql.generator.SchemaGenerator
+import com.expedia.graphql.generator.TypeBuilder
+import com.expedia.graphql.generator.extensions.getValidFunctions
+import graphql.schema.GraphQLObjectType
+
+internal class MutationTypeBuilder(generator: SchemaGenerator) : TypeBuilder(generator) {
+
+    fun getMutationObject(mutations: List<TopLevelObject>): GraphQLObjectType? {
+
+        if (mutations.isEmpty()) {
+            return null
+        }
+
+        val mutationBuilder = GraphQLObjectType.Builder()
+        mutationBuilder.name(config.topLevelMutationName)
+
+        for (mutation in mutations) {
+            mutation.kClass.getValidFunctions(config.hooks)
+                .forEach {
+                    val function = generator.function(it, mutation.obj)
+                    val functionFromHook = config.hooks.didGenerateMutationType(it, function)
+                    mutationBuilder.field(functionFromHook)
+                }
+        }
+
+        return mutationBuilder.build()
+    }
+}

--- a/src/main/kotlin/com/expedia/graphql/generator/types/QueryTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/QueryTypeBuilder.kt
@@ -1,0 +1,33 @@
+package com.expedia.graphql.generator.types
+
+import com.expedia.graphql.TopLevelObject
+import com.expedia.graphql.exceptions.InvalidSchemaException
+import com.expedia.graphql.generator.SchemaGenerator
+import com.expedia.graphql.generator.TypeBuilder
+import com.expedia.graphql.generator.extensions.getValidFunctions
+import graphql.schema.GraphQLObjectType
+
+internal class QueryTypeBuilder(generator: SchemaGenerator) : TypeBuilder(generator) {
+
+    @Throws(InvalidSchemaException::class)
+    fun getQueryObject(queries: List<TopLevelObject>): GraphQLObjectType {
+
+        if (queries.isEmpty()) {
+            throw InvalidSchemaException()
+        }
+
+        val queryBuilder = GraphQLObjectType.Builder()
+        queryBuilder.name(config.topLevelQueryName)
+
+        for (query in queries) {
+            query.kClass.getValidFunctions(config.hooks)
+                .forEach {
+                    val function = generator.function(it, query.obj)
+                    val functionFromHook = config.hooks.didGenerateQueryType(it, function)
+                    queryBuilder.field(functionFromHook)
+                }
+        }
+
+        return queryBuilder.build()
+    }
+}

--- a/src/main/kotlin/com/expedia/graphql/toSchema.kt
+++ b/src/main/kotlin/com/expedia/graphql/toSchema.kt
@@ -1,7 +1,6 @@
 package com.expedia.graphql
 
 import com.expedia.graphql.exceptions.GraphQLKotlinException
-import com.expedia.graphql.exceptions.InvalidSchemaException
 import com.expedia.graphql.generator.SchemaGenerator
 import graphql.schema.GraphQLSchema
 
@@ -20,10 +19,6 @@ fun toSchema(
     mutations: List<TopLevelObject> = emptyList(),
     config: SchemaGeneratorConfig
 ): GraphQLSchema {
-
-    if (queries.isEmpty()) {
-        throw InvalidSchemaException()
-    }
-
-    return SchemaGenerator(queries, mutations, config).generate()
+    val generator = SchemaGenerator(config)
+    return generator.generate(queries, mutations)
 }

--- a/src/test/kotlin/com/expedia/graphql/ToSchemaKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/ToSchemaKtTest.kt
@@ -1,8 +1,6 @@
 package com.expedia.graphql
 
-import com.expedia.graphql.exceptions.InvalidSchemaException
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
 
 internal class ToSchemaKtTest {
 
@@ -12,20 +10,5 @@ internal class ToSchemaKtTest {
     fun `valid schema`() {
         val queries = listOf(TopLevelObject(TestClass()))
         toSchema(queries = queries, config = testSchemaConfig)
-    }
-
-    @Test
-    fun `empty queries and mutations`() {
-        val mutations = listOf(TopLevelObject(TestClass()))
-        assertFailsWith(InvalidSchemaException::class) {
-            toSchema(queries = emptyList(), mutations = mutations, config = testSchemaConfig)
-        }
-    }
-
-    @Test
-    fun `empty queries with mutations`() {
-        assertFailsWith(InvalidSchemaException::class) {
-            toSchema(queries = emptyList(), config = testSchemaConfig)
-        }
     }
 }

--- a/src/test/kotlin/com/expedia/graphql/generator/types/DirectiveTypeBuilderTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/DirectiveTypeBuilderTest.kt
@@ -48,7 +48,7 @@ internal class DirectiveTypeBuilderTest {
         fun directiveWithClass(string: String) = string
     }
 
-    private val basicGenerator = SchemaGenerator(emptyList(), emptyList(), testSchemaConfig)
+    private val basicGenerator = SchemaGenerator(testSchemaConfig)
 
     @Test
     fun `no annotation`() {

--- a/src/test/kotlin/com/expedia/graphql/generator/types/MutationTypeBuilderTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/MutationTypeBuilderTest.kt
@@ -1,0 +1,74 @@
+package com.expedia.graphql.generator.types
+
+import com.expedia.graphql.TopLevelObject
+import com.expedia.graphql.annotations.GraphQLDescription
+import com.expedia.graphql.annotations.GraphQLIgnore
+import com.expedia.graphql.generator.extensions.isTrue
+import com.expedia.graphql.hooks.SchemaGeneratorHooks
+import graphql.schema.GraphQLFieldDefinition
+import kotlin.reflect.KFunction
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+internal class MutationTypeBuilderTest : TypeTestHelper() {
+
+    internal class SimpleHooks : SchemaGeneratorHooks {
+        var calledHook = false
+        override fun didGenerateMutationType(function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
+            calledHook = true
+            return super.didGenerateMutationType(function, fieldDefinition)
+        }
+    }
+
+    internal class MutationObject {
+        @GraphQLDescription("A GraphQL mutation method")
+        fun mutation(value: Int) = value
+    }
+
+    internal class NoFunctions {
+        @GraphQLIgnore
+        fun hidden(value: Int) = value
+    }
+
+    private lateinit var builder: MutationTypeBuilder
+
+    override fun beforeSetup() {
+        hooks = SimpleHooks()
+    }
+
+    override fun beforeTest() {
+        builder = MutationTypeBuilder(generator)
+    }
+
+    @Test
+    fun `empty list`() {
+        assertNull(builder.getMutationObject(emptyList()))
+    }
+
+    @Test
+    fun `mutation with no valid functions`() {
+        val queries = listOf(TopLevelObject(NoFunctions()))
+        val result = builder.getMutationObject(queries)
+        assertEquals(expected = "TestTopLevelMutation", actual = result?.name)
+        assertTrue(result?.fieldDefinitions?.isEmpty().isTrue())
+    }
+
+    @Test
+    fun `mutation with valid functions`() {
+        val queries = listOf(TopLevelObject(MutationObject()))
+        val result = builder.getMutationObject(queries)
+        assertEquals(expected = "TestTopLevelMutation", actual = result?.name)
+        assertEquals(expected = 1, actual = result?.fieldDefinitions?.size)
+        assertEquals(expected = "mutation", actual = result?.fieldDefinitions?.firstOrNull()?.name)
+    }
+
+    @Test
+    fun `verify hooks are called`() {
+        assertFalse((hooks as? SimpleHooks)?.calledHook.isTrue())
+        builder.getMutationObject(listOf(TopLevelObject(MutationObject())))
+        assertTrue((hooks as? SimpleHooks)?.calledHook.isTrue())
+    }
+}

--- a/src/test/kotlin/com/expedia/graphql/generator/types/QueryTypeBuilderTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/QueryTypeBuilderTest.kt
@@ -1,0 +1,77 @@
+package com.expedia.graphql.generator.types
+
+import com.expedia.graphql.TopLevelObject
+import com.expedia.graphql.annotations.GraphQLDescription
+import com.expedia.graphql.annotations.GraphQLIgnore
+import com.expedia.graphql.exceptions.InvalidSchemaException
+import com.expedia.graphql.generator.extensions.isTrue
+import com.expedia.graphql.hooks.SchemaGeneratorHooks
+import graphql.schema.GraphQLFieldDefinition
+import kotlin.reflect.KFunction
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class QueryTypeBuilderTest : TypeTestHelper() {
+
+    internal class SimpleHooks : SchemaGeneratorHooks {
+        var calledHook = false
+        override fun didGenerateQueryType(function: KFunction<*>, fieldDefinition: GraphQLFieldDefinition): GraphQLFieldDefinition {
+            calledHook = true
+            return super.didGenerateQueryType(function, fieldDefinition)
+        }
+    }
+
+    internal class QueryObject {
+        @GraphQLDescription("A GraphQL query method")
+        fun query(value: Int) = value
+    }
+
+    internal class NoFunctions {
+        @GraphQLIgnore
+        fun hidden(value: Int) = value
+    }
+
+    private lateinit var builder: QueryTypeBuilder
+
+    override fun beforeSetup() {
+        hooks = SimpleHooks()
+    }
+
+    override fun beforeTest() {
+        builder = QueryTypeBuilder(generator)
+    }
+
+    @Test
+    fun `empty list`() {
+        assertFailsWith(InvalidSchemaException::class) {
+            builder.getQueryObject(emptyList())
+        }
+    }
+
+    @Test
+    fun `query with no valid functions`() {
+        val queries = listOf(TopLevelObject(NoFunctions()))
+        val result = builder.getQueryObject(queries)
+        assertEquals(expected = "TestTopLevelQuery", actual = result.name)
+        assertTrue(result.fieldDefinitions.isEmpty())
+    }
+
+    @Test
+    fun `query with valid functions`() {
+        val queries = listOf(TopLevelObject(QueryObject()))
+        val result = builder.getQueryObject(queries)
+        assertEquals(expected = "TestTopLevelQuery", actual = result.name)
+        assertEquals(expected = 1, actual = result.fieldDefinitions.size)
+        assertEquals(expected = "query", actual = result.fieldDefinitions.first().name)
+    }
+
+    @Test
+    fun `verify hooks are called`() {
+        assertFalse((hooks as? SimpleHooks)?.calledHook.isTrue())
+        builder.getQueryObject(listOf(TopLevelObject(QueryObject())))
+        assertTrue((hooks as? SimpleHooks)?.calledHook.isTrue())
+    }
+}

--- a/src/test/kotlin/com/expedia/graphql/generator/types/TypeTestHelper.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/TypeTestHelper.kt
@@ -6,18 +6,22 @@ import com.expedia.graphql.generator.SubTypeMapper
 import com.expedia.graphql.generator.state.SchemaGeneratorState
 import com.expedia.graphql.generator.state.TypesCache
 import com.expedia.graphql.hooks.NoopSchemaGeneratorHooks
+import com.expedia.graphql.hooks.SchemaGeneratorHooks
 import graphql.schema.GraphQLInterfaceType
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 import kotlin.test.BeforeTest
 
 @Suppress(
     "Detekt.UnsafeCast",
-    "Detekt.UnsafeCallOnNullableType"
+    "Detekt.UnsafeCallOnNullableType",
+    "Detekt.LongMethod"
 )
 internal open class TypeTestHelper {
     var generator = mockk<SchemaGenerator>()
@@ -25,19 +29,36 @@ internal open class TypeTestHelper {
     var state = spyk(SchemaGeneratorState(listOf("com.expedia.graphql.generator.types")))
     var subTypeMapper = spyk(SubTypeMapper(listOf("com.expedia.graphql.generator.types")))
     var cache = spyk(TypesCache(listOf("com.expedia.graphql.generator.types")))
-    var hooks = NoopSchemaGeneratorHooks()
-    var scalarTypeBuilder: ScalarTypeBuilder? = null
-    var objectTypeBuilder: ObjectTypeBuilder? = null
-    var directiveTypeBuilder: DirectiveTypeBuilder? = null
+    var hooks: SchemaGeneratorHooks = NoopSchemaGeneratorHooks()
+
+    private var scalarTypeBuilder: ScalarTypeBuilder? = null
+    private var objectTypeBuilder: ObjectTypeBuilder? = null
+    private var directiveTypeBuilder: DirectiveTypeBuilder? = null
+    private var functionTypeBuilder: FunctionTypeBuilder? = null
+    private var propertyTypeBuilder: PropertyTypeBuilder? = null
 
     @BeforeTest
     fun setup() {
+        beforeSetup()
+
         every { generator.state } returns state
         every { state.cache } returns cache
         every { generator.config } returns config
         every { generator.subTypeMapper } returns subTypeMapper
         every { config.hooks } returns hooks
         every { config.dataFetcherFactory } returns null
+        every { config.topLevelQueryName } returns "TestTopLevelQuery"
+        every { config.topLevelMutationName } returns "TestTopLevelMutation"
+
+        functionTypeBuilder = spyk(FunctionTypeBuilder(generator))
+        every { generator.function(any(), any(), any()) } answers {
+            functionTypeBuilder!!.function(it.invocation.args[0] as KFunction<*>, it.invocation.args[1], it.invocation.args[2] as Boolean)
+        }
+
+        propertyTypeBuilder = spyk(PropertyTypeBuilder(generator))
+        every { generator.property(any(), any()) } answers {
+            propertyTypeBuilder!!.property(it.invocation.args[0] as KProperty<*>, it.invocation.args[1] as KClass<*>)
+        }
 
         scalarTypeBuilder = spyk(ScalarTypeBuilder(generator))
         every { generator.scalarType(any(), any()) } answers {
@@ -60,4 +81,6 @@ internal open class TypeTestHelper {
     }
 
     open fun beforeTest() {}
+
+    open fun beforeSetup() {}
 }


### PR DESCRIPTION
Move the query and mutation builder code to their own TypeBuilder class