### PR TITLE
refactor: simplify type cache

### DIFF
--- a/example/src/main/kotlin/com/expedia/graphql/sample/extension/CustomSchemaGeneratorHooks.kt
+++ b/example/src/main/kotlin/com/expedia/graphql/sample/extension/CustomSchemaGeneratorHooks.kt
@@ -10,7 +10,6 @@ import graphql.schema.GraphQLScalarType
 import graphql.schema.GraphQLType
 import java.util.UUID
 import javax.validation.Validator
-import kotlin.reflect.KClass
 import kotlin.reflect.KType
 
 /**
@@ -21,7 +20,7 @@ class CustomSchemaGeneratorHooks(validator: Validator, private val directiveWiri
     /**
      * Register additional GraphQL scalar types.
      */
-    override fun willGenerateGraphQLType(type: KType): GraphQLType? = when (type.classifier as? KClass<*>) {
+    override fun willGenerateGraphQLType(type: KType): GraphQLType? = when (type.classifier) {
         UUID::class -> graphqlUUIDType
         else -> null
     }

--- a/example/src/main/kotlin/com/expedia/graphql/sample/model/Node.kt
+++ b/example/src/main/kotlin/com/expedia/graphql/sample/model/Node.kt
@@ -1,0 +1,12 @@
+package com.expedia.graphql.sample.model
+
+/**
+ * Represents a recursive type that references itself,
+ * similar to a tree node structure.
+ */
+data class Node(
+    val id: Int,
+    val value: String,
+    val parent: Node?,
+    var children: List<Node>
+)

--- a/example/src/main/kotlin/com/expedia/graphql/sample/query/RecursiveQuery.kt
+++ b/example/src/main/kotlin/com/expedia/graphql/sample/query/RecursiveQuery.kt
@@ -1,0 +1,22 @@
+package com.expedia.graphql.sample.query
+
+import com.expedia.graphql.annotations.GraphQLDescription
+import com.expedia.graphql.sample.model.Node
+import org.springframework.stereotype.Component
+
+@Component
+class RecursiveQuery : Query {
+
+    private final val root = Node(id = 0, value = "root", parent = null, children = emptyList())
+    private final val nodeA = Node(id = 1, value = "A", parent = root, children = emptyList())
+    private final val nodeB = Node(id = 2, value = "B", parent = root, children = emptyList())
+    private final val nodeC = Node(id = 3, value = "C", parent = nodeB, children = emptyList())
+
+    init {
+        root.children = listOf(nodeA, nodeB)
+        nodeB.children = listOf(nodeC)
+    }
+
+    @GraphQLDescription("Returns the root of a node graph")
+    fun nodeGraph(): Node = root
+}

--- a/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotCastToKClassException.kt
+++ b/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotCastToKClassException.kt
@@ -1,9 +1,0 @@
-package com.expedia.graphql.exceptions
-
-import kotlin.reflect.KType
-
-/**
- * Thrown if could not cast the KType.classifier to KClass
- */
-class CouldNotCastToKClassException(kType: KType)
-    : GraphQLKotlinException("Could not cast the KType.classifier to KClass. KType=$kType")

--- a/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetNameOfKTypeException.kt
+++ b/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotGetNameOfKTypeException.kt
@@ -1,9 +1,0 @@
-package com.expedia.graphql.exceptions
-
-import kotlin.reflect.KType
-
-/**
- * Thrown when trying to generate a type and cannot resolve the name.
- */
-class CouldNotGetNameOfKTypeException(kType: KType)
-    : GraphQLKotlinException("Could not get the name of the KType $kType")

--- a/src/main/kotlin/com/expedia/graphql/exceptions/TypeNotSupportedException.kt
+++ b/src/main/kotlin/com/expedia/graphql/exceptions/TypeNotSupportedException.kt
@@ -1,7 +1,9 @@
 package com.expedia.graphql.exceptions
 
+import kotlin.reflect.KType
+
 /**
  * Thrown when the generator does not have a type to map to in GraphQL or in the hooks.
  */
-class TypeNotSupportedException(typeName: String, packageList: List<String>)
-    : GraphQLKotlinException("Cannot convert $typeName since it is outside the supported packages $packageList")
+class TypeNotSupportedException(kType: KType, packageList: List<String>)
+    : GraphQLKotlinException("Cannot convert $kType since it is outside the supported packages $packageList")

--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/kClassExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/kClassExtensions.kt
@@ -38,6 +38,8 @@ internal fun KClass<*>.isList(): Boolean = this.isSubclassOf(List::class)
 
 internal fun KClass<*>.isArray(): Boolean = this.java.isArray
 
+internal fun KClass<*>.isListType(): Boolean = this.isList() || this.isArray()
+
 @Throws(CouldNotGetNameOfKClassException::class)
 internal fun KClass<*>.getSimpleName(): String =
     this.simpleName ?: throw CouldNotGetNameOfKClassException(this)

--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/kParameterExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/kParameterExtensions.kt
@@ -4,9 +4,8 @@ import com.expedia.graphql.annotations.GraphQLContext
 import com.expedia.graphql.exceptions.CouldNotGetNameOfKParameterException
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.findAnnotation
-import kotlin.reflect.jvm.jvmErasure
 
-internal fun KParameter.isInterface() = this.type.jvmErasure.isInterface()
+internal fun KParameter.isInterface() = this.type.getKClass().isInterface()
 
 internal fun KParameter.isGraphQLContext() = this.findAnnotation<GraphQLContext>() != null
 

--- a/src/main/kotlin/com/expedia/graphql/generator/types/ListTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/ListTypeBuilder.kt
@@ -1,6 +1,6 @@
 package com.expedia.graphql.generator.types
 
-import com.expedia.graphql.generator.extensions.getArrayType
+import com.expedia.graphql.generator.extensions.getWrappedType
 import com.expedia.graphql.generator.extensions.getTypeOfFirstArgument
 import com.expedia.graphql.generator.SchemaGenerator
 import com.expedia.graphql.generator.TypeBuilder
@@ -9,7 +9,7 @@ import kotlin.reflect.KType
 
 internal class ListTypeBuilder(generator: SchemaGenerator) : TypeBuilder(generator) {
     internal fun arrayType(type: KType, inputType: Boolean): GraphQLList =
-        GraphQLList.list(graphQLTypeOf(type.getArrayType(), inputType))
+        GraphQLList.list(graphQLTypeOf(type.getWrappedType(), inputType))
 
     internal fun listType(type: KType, inputType: Boolean): GraphQLList =
         GraphQLList.list(graphQLTypeOf(type.getTypeOfFirstArgument(), inputType))

--- a/src/test/kotlin/com/expedia/graphql/generator/SchemaGeneratorTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/SchemaGeneratorTest.kt
@@ -5,6 +5,7 @@ import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.annotations.GraphQLID
 import com.expedia.graphql.annotations.GraphQLIgnore
 import com.expedia.graphql.exceptions.ConflictingTypesException
+import com.expedia.graphql.exceptions.GraphQLKotlinException
 import com.expedia.graphql.exceptions.InvalidIdTypeException
 import com.expedia.graphql.extensions.deepName
 import com.expedia.graphql.testSchemaConfig
@@ -197,8 +198,15 @@ class SchemaGeneratorTest {
 
     @Test
     fun `SchemaGenerator throws when encountering java stdlib`() {
-        assertFailsWith(RuntimeException::class) {
+        assertFailsWith(GraphQLKotlinException::class) {
             toSchema(listOf(TopLevelObject(QueryWithJavaClass())), config = testSchemaConfig)
+        }
+    }
+
+    @Test
+    fun `SchemaGenerator throws when encountering list of java stdlib`() {
+        assertFailsWith(GraphQLKotlinException::class) {
+            toSchema(listOf(TopLevelObject(QueryWithListOfJavaClass())), config = testSchemaConfig)
         }
     }
 
@@ -367,6 +375,10 @@ class SchemaGeneratorTest {
 
     class QueryWithJavaClass {
         fun query(): java.net.CookieManager? = CookieManager()
+    }
+
+    class QueryWithListOfJavaClass {
+        fun listQuery(): List<java.net.CookieManager> = listOf(CookieManager())
     }
 
     class QueryWithConflictingTypes {

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/KClassExtensionsTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/KClassExtensionsTest.kt
@@ -115,6 +115,14 @@ internal class KClassExtensionsTest {
     }
 
     @Test
+    fun `test listType extension`() {
+        assertTrue(arrayOf(1)::class.isListType())
+        assertTrue(intArrayOf(1)::class.isListType())
+        assertTrue(listOf(1)::class.isListType())
+        assertFalse(MyTestClass::class.isListType())
+    }
+
+    @Test
     fun `test graphql interface extension`() {
         assertTrue(TestInterface::class.isInterface())
         assertFalse(MyTestClass::class.isInterface())

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/KTypeExtensionsKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/KTypeExtensionsKtTest.kt
@@ -1,7 +1,6 @@
 package com.expedia.graphql.generator.extensions
 
-import com.expedia.graphql.exceptions.CouldNotCastToKClassException
-import com.expedia.graphql.exceptions.CouldNotGetNameOfKTypeException
+import com.expedia.graphql.exceptions.CouldNotGetNameOfKClassException
 import com.expedia.graphql.exceptions.InvalidListTypeException
 import io.mockk.every
 import io.mockk.mockk
@@ -31,7 +30,7 @@ internal class KTypeExtensionsKtTest {
 
         assertEquals(String::class.starProjectedType, MyClass::arrayFun.findParameterByName("array")?.type?.getTypeOfFirstArgument())
 
-        assertEquals(Int::class.starProjectedType, MyClass::primitiveArrayFun.findParameterByName("intArray")?.type?.getArrayType())
+        assertEquals(Int::class.starProjectedType, MyClass::primitiveArrayFun.findParameterByName("intArray")?.type?.getWrappedType())
 
         assertFailsWith(InvalidListTypeException::class) {
             MyClass::stringFun.findParameterByName("string")?.type?.getTypeOfFirstArgument()
@@ -58,39 +57,26 @@ internal class KTypeExtensionsKtTest {
     }
 
     @Test
-    fun `getKClass exception`() {
-        assertFailsWith(CouldNotCastToKClassException::class) {
-            val mockType: KType = mockk()
-            every { mockType.classifier } returns null
-            mockType.getKClass()
-        }
-    }
-
-    @Test
     fun getArrayType() {
-        assertEquals(Int::class.starProjectedType, IntArray::class.starProjectedType.getArrayType())
-        assertEquals(Long::class.starProjectedType, LongArray::class.starProjectedType.getArrayType())
-        assertEquals(Short::class.starProjectedType, ShortArray::class.starProjectedType.getArrayType())
-        assertEquals(Float::class.starProjectedType, FloatArray::class.starProjectedType.getArrayType())
-        assertEquals(Double::class.starProjectedType, DoubleArray::class.starProjectedType.getArrayType())
-        assertEquals(Char::class.starProjectedType, CharArray::class.starProjectedType.getArrayType())
-        assertEquals(Boolean::class.starProjectedType, BooleanArray::class.starProjectedType.getArrayType())
-        assertEquals(String::class.starProjectedType, MyClass::listFun.findParameterByName("list")?.type?.getArrayType())
+        assertEquals(Int::class.starProjectedType, IntArray::class.starProjectedType.getWrappedType())
+        assertEquals(Long::class.starProjectedType, LongArray::class.starProjectedType.getWrappedType())
+        assertEquals(Short::class.starProjectedType, ShortArray::class.starProjectedType.getWrappedType())
+        assertEquals(Float::class.starProjectedType, FloatArray::class.starProjectedType.getWrappedType())
+        assertEquals(Double::class.starProjectedType, DoubleArray::class.starProjectedType.getWrappedType())
+        assertEquals(Char::class.starProjectedType, CharArray::class.starProjectedType.getWrappedType())
+        assertEquals(Boolean::class.starProjectedType, BooleanArray::class.starProjectedType.getWrappedType())
+        assertEquals(String::class.starProjectedType, MyClass::listFun.findParameterByName("list")?.type?.getWrappedType())
 
         assertFailsWith(InvalidListTypeException::class) {
-            MyClass::stringFun.findParameterByName("string")?.type?.getArrayType()
+            MyClass::stringFun.findParameterByName("string")?.type?.getWrappedType()
         }
     }
 
     @Test
     fun getSimpleName() {
         assertEquals("MyClass", MyClass::class.starProjectedType.getSimpleName())
-    }
-
-    @Test
-    fun getSimpleNameException() {
-        assertFailsWith(CouldNotGetNameOfKTypeException::class) {
-            object { }::class.starProjectedType.getSimpleName()
+        assertFailsWith(CouldNotGetNameOfKClassException::class) {
+            object {}::class.starProjectedType.getSimpleName()
         }
     }
 
@@ -98,5 +84,20 @@ internal class KTypeExtensionsKtTest {
     fun qualifiedName() {
         assertEquals("com.expedia.graphql.generator.extensions.KTypeExtensionsKtTest.MyClass", MyClass::class.starProjectedType.qualifiedName)
         assertEquals("", object { }::class.starProjectedType.qualifiedName)
+    }
+
+    @Test
+    fun getName() {
+        assertEquals("MyClass", MyClass::class.starProjectedType.getWrappedName())
+
+        assertEquals("List<String>", MyClass::listFun.findParameterByName("list")?.type?.getWrappedName())
+
+        assertEquals("Array<String>", MyClass::arrayFun.findParameterByName("array")?.type?.getWrappedName())
+
+        assertEquals("IntArray", MyClass::primitiveArrayFun.findParameterByName("intArray")?.type?.getWrappedName())
+
+        assertFailsWith(CouldNotGetNameOfKClassException::class) {
+            object {}::class.starProjectedType.getWrappedName()
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ExpediaDotCom/graphql-kotlin/issues/113

* Move the primitive types map to a single location
* Move extracting the cache name to extension functions
* Deleted unused exceptions