### PR TITLE
refactor: use input name in cache

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/generator/SchemaGenerator.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/SchemaGenerator.kt
@@ -65,9 +65,6 @@ internal class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
     internal fun listType(type: KType, inputType: Boolean) =
         listTypeBuilder.listType(type, inputType)
 
-    internal fun arrayType(type: KType, inputType: Boolean) =
-        listTypeBuilder.arrayType(type, inputType)
-
     internal fun objectType(kClass: KClass<*>, interfaceType: GraphQLInterfaceType? = null) =
         objectTypeBuilder.objectType(kClass, interfaceType)
 

--- a/src/main/kotlin/com/expedia/graphql/generator/TypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/TypeBuilder.kt
@@ -1,10 +1,9 @@
 package com.expedia.graphql.generator
 
 import com.expedia.graphql.generator.extensions.getKClass
-import com.expedia.graphql.generator.extensions.isArray
 import com.expedia.graphql.generator.extensions.isEnum
 import com.expedia.graphql.generator.extensions.isInterface
-import com.expedia.graphql.generator.extensions.isList
+import com.expedia.graphql.generator.extensions.isListType
 import com.expedia.graphql.generator.extensions.isUnion
 import com.expedia.graphql.generator.extensions.wrapInNonNull
 import com.expedia.graphql.generator.state.KGraphQLType
@@ -47,8 +46,7 @@ internal open class TypeBuilder constructor(protected val generator: SchemaGener
 
     private fun getGraphQLType(kClass: KClass<*>, inputType: Boolean, type: KType): GraphQLType = when {
         kClass.isEnum() -> @Suppress("UNCHECKED_CAST") (generator.enumType(kClass as KClass<Enum<*>>))
-        kClass.isArray() -> generator.arrayType(type, inputType)
-        kClass.isList() -> generator.listType(type, inputType)
+        kClass.isListType() -> generator.listType(type, inputType)
         kClass.isUnion() -> generator.unionType(kClass)
         kClass.isInterface() -> generator.interfaceType(kClass)
         inputType -> generator.inputObjectType(kClass)

--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/kClassExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/kClassExtensions.kt
@@ -41,9 +41,13 @@ internal fun KClass<*>.isArray(): Boolean = this.java.isArray
 internal fun KClass<*>.isListType(): Boolean = this.isList() || this.isArray()
 
 @Throws(CouldNotGetNameOfKClassException::class)
-internal fun KClass<*>.getSimpleName(): String =
-    this.simpleName ?: throw CouldNotGetNameOfKClassException(this)
+internal fun KClass<*>.getSimpleName(isInputClass: Boolean = false): String {
+    val name = this.simpleName ?: throw CouldNotGetNameOfKClassException(this)
 
-internal fun KClass<*>.getInputClassName(): String = "${this.getSimpleName()}Input"
+    return when {
+        isInputClass -> "${name}Input"
+        else -> name
+    }
+}
 
 internal fun KClass<*>.getQualifiedName(): String = this.qualifiedName ?: ""

--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/kTypeExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/kTypeExtensions.kt
@@ -29,17 +29,17 @@ internal fun KType.getWrappedType(): KType {
     }
 }
 
-internal fun KType.getWrappedName(): String {
+internal fun KType.getWrappedName(isInputType: Boolean = false): String {
     val isPrimitiveArray = primitiveArrayTypes.containsKey(this.getKClass())
     return when {
         isPrimitiveArray -> this.getSimpleName()
-        this.getKClass().isList() -> "List<${this.getWrappedType().getSimpleName()}>"
-        this.getKClass().isArray() -> "Array<${this.getWrappedType().getSimpleName()}>"
-        else -> this.getSimpleName()
+        this.getKClass().isList() -> "List<${this.getWrappedType().getSimpleName(isInputType)}>"
+        this.getKClass().isArray() -> "Array<${this.getWrappedType().getSimpleName(isInputType)}>"
+        else -> this.getSimpleName(isInputType)
     }
 }
 
-internal fun KType.getSimpleName(): String = this.getKClass().getSimpleName()
+internal fun KType.getSimpleName(isInputType: Boolean = false): String = this.getKClass().getSimpleName(isInputType)
 
 internal val KType.qualifiedName: String
     get() = this.getKClass().getQualifiedName()

--- a/src/main/kotlin/com/expedia/graphql/generator/state/TypesCache.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/state/TypesCache.kt
@@ -56,9 +56,7 @@ internal class TypesCache(private val supportedPackages: List<String>) {
             throw TypeNotSupportedException(cacheKey.type, supportedPackages)
         }
 
-        val cacheKeyFromTypeName = cacheKey.type.getWrappedName()
-
-        return "$cacheKeyFromTypeName:${cacheKey.inputType}"
+        return cacheKey.type.getWrappedName(cacheKey.inputType)
     }
 
     private fun isTypeNotSupported(type: KType): Boolean {

--- a/src/main/kotlin/com/expedia/graphql/generator/types/InputObjectTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/InputObjectTypeBuilder.kt
@@ -3,8 +3,8 @@ package com.expedia.graphql.generator.types
 import com.expedia.graphql.generator.SchemaGenerator
 import com.expedia.graphql.generator.TypeBuilder
 import com.expedia.graphql.generator.extensions.getGraphQLDescription
-import com.expedia.graphql.generator.extensions.getInputClassName
 import com.expedia.graphql.generator.extensions.getPropertyDescription
+import com.expedia.graphql.generator.extensions.getSimpleName
 import com.expedia.graphql.generator.extensions.getValidProperties
 import com.expedia.graphql.generator.extensions.isPropertyGraphQLID
 import graphql.schema.GraphQLInputObjectField
@@ -17,7 +17,7 @@ internal class InputObjectTypeBuilder(generator: SchemaGenerator) : TypeBuilder(
     internal fun inputObjectType(kClass: KClass<*>): GraphQLInputObjectType {
         val builder = GraphQLInputObjectType.newInputObject()
 
-        builder.name(kClass.getInputClassName())
+        builder.name(kClass.getSimpleName(isInputClass = true))
         builder.description(kClass.getGraphQLDescription())
 
         // It does not make sense to run functions against the input types so we only process the properties

--- a/src/main/kotlin/com/expedia/graphql/generator/types/ListTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/ListTypeBuilder.kt
@@ -1,16 +1,14 @@
 package com.expedia.graphql.generator.types
 
-import com.expedia.graphql.generator.extensions.getWrappedType
-import com.expedia.graphql.generator.extensions.getTypeOfFirstArgument
 import com.expedia.graphql.generator.SchemaGenerator
 import com.expedia.graphql.generator.TypeBuilder
+import com.expedia.graphql.generator.extensions.getWrappedType
 import graphql.schema.GraphQLList
 import kotlin.reflect.KType
 
 internal class ListTypeBuilder(generator: SchemaGenerator) : TypeBuilder(generator) {
-    internal fun arrayType(type: KType, inputType: Boolean): GraphQLList =
-        GraphQLList.list(graphQLTypeOf(type.getWrappedType(), inputType))
-
-    internal fun listType(type: KType, inputType: Boolean): GraphQLList =
-        GraphQLList.list(graphQLTypeOf(type.getTypeOfFirstArgument(), inputType))
+    internal fun listType(type: KType, inputType: Boolean): GraphQLList {
+        val wrappedType = graphQLTypeOf(type.getWrappedType(), inputType)
+        return GraphQLList.list(wrappedType)
+    }
 }

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/KClassExtensionsTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/KClassExtensionsTest.kt
@@ -145,7 +145,7 @@ internal class KClassExtensionsTest {
 
     @Test
     fun `test input class name`() {
-        assertEquals("MyTestClassInput", MyTestClass::class.getInputClassName())
+        assertEquals("MyTestClassInput", MyTestClass::class.getSimpleName(true))
     }
 
     @Test

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/KTypeExtensionsKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/KTypeExtensionsKtTest.kt
@@ -75,6 +75,7 @@ internal class KTypeExtensionsKtTest {
     @Test
     fun getSimpleName() {
         assertEquals("MyClass", MyClass::class.starProjectedType.getSimpleName())
+        assertEquals("MyClassInput", MyClass::class.starProjectedType.getSimpleName(isInputType = true))
         assertFailsWith(CouldNotGetNameOfKClassException::class) {
             object {}::class.starProjectedType.getSimpleName()
         }
@@ -90,11 +91,17 @@ internal class KTypeExtensionsKtTest {
     fun getName() {
         assertEquals("MyClass", MyClass::class.starProjectedType.getWrappedName())
 
+        assertEquals("MyClassInput", MyClass::class.starProjectedType.getWrappedName(isInputType = true))
+
         assertEquals("List<String>", MyClass::listFun.findParameterByName("list")?.type?.getWrappedName())
+
+        assertEquals("List<StringInput>", MyClass::listFun.findParameterByName("list")?.type?.getWrappedName(isInputType = true))
 
         assertEquals("Array<String>", MyClass::arrayFun.findParameterByName("array")?.type?.getWrappedName())
 
         assertEquals("IntArray", MyClass::primitiveArrayFun.findParameterByName("intArray")?.type?.getWrappedName())
+
+        assertEquals("IntArray", MyClass::primitiveArrayFun.findParameterByName("intArray")?.type?.getWrappedName(isInputType = true))
 
         assertFailsWith(CouldNotGetNameOfKClassException::class) {
             object {}::class.starProjectedType.getWrappedName()

--- a/src/test/kotlin/com/expedia/graphql/generator/types/ListTypeTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/ListTypeTest.kt
@@ -1,15 +1,17 @@
 package com.expedia.graphql.generator.types
 
-import com.expedia.graphql.generator.extensions.getValidProperties
 import graphql.schema.GraphQLNonNull
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
+@Suppress("Detekt.UnusedPrivateClass")
 internal class ListTypeTest : TypeTestHelper() {
 
-    @Suppress("Detekt.UnusedPrivateClass")
+    private data class MyDataClass(val id: String)
+
     private class ClassWithListAndArray {
         val testList = listOf<Int>()
+        val testListOfClass = listOf<MyDataClass>()
         val testArray = arrayOf<String>()
         val primitiveArray = booleanArrayOf(true)
     }
@@ -21,26 +23,34 @@ internal class ListTypeTest : TypeTestHelper() {
     }
 
     @Test
-    fun `test list`() {
-        val listProp = ClassWithListAndArray::class.getValidProperties(hooks).first { it.name == "testList" }
+    fun `test list of primitive`() {
+        val listProp = ClassWithListAndArray::testList
 
         val result = builder.listType(listProp.returnType, false)
         assertEquals(Int::class.simpleName, (result.wrappedType as? GraphQLNonNull)?.wrappedType?.name)
     }
 
     @Test
-    fun `test array`() {
-        val arrayProp = ClassWithListAndArray::class.getValidProperties(hooks).first { it.name == "testArray" }
+    fun `test list of class`() {
+        val listProp = ClassWithListAndArray::testListOfClass
 
-        val result = builder.arrayType(arrayProp.returnType, false)
+        val result = builder.listType(listProp.returnType, false)
+        assertEquals(MyDataClass::class.simpleName, (result.wrappedType as? GraphQLNonNull)?.wrappedType?.name)
+    }
+
+    @Test
+    fun `test array`() {
+        val arrayProp = ClassWithListAndArray::testArray
+
+        val result = builder.listType(arrayProp.returnType, false)
         assertEquals(String::class.simpleName, (result.wrappedType as? GraphQLNonNull)?.wrappedType?.name)
     }
 
     @Test
     fun `test array of primitives`() {
-        val primitiveArray = ClassWithListAndArray::class.getValidProperties(hooks).first { it.name == "primitiveArray" }
+        val primitiveArray = ClassWithListAndArray::primitiveArray
 
-        val result = builder.arrayType(primitiveArray.returnType, false)
+        val result = builder.listType(primitiveArray.returnType, false)
         assertEquals(Boolean::class.simpleName, (result.wrappedType as? GraphQLNonNull)?.wrappedType?.name)
     }
 }


### PR DESCRIPTION
Internal changes only

By using the full input name in the cache we have less string building logic and it makes it easier to debug when you inspect the values

Inspecting the cache locally:

BEFORE
![screen shot 2019-01-02 at 14 05 17 pm](https://user-images.githubusercontent.com/2446877/50614953-70fd2680-0e97-11e9-8b40-48aa88fff5d2.png)


AFTER

![screen shot 2019-01-02 at 13 53 19 pm](https://user-images.githubusercontent.com/2446877/50614819-f0d6c100-0e96-11e9-9cbb-248eac4bcf8d.png)
