### PR TITLE
Update javadoc badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/ExpediaDotCom/graphql-kotlin.svg?branch=master)](https://travis-ci.org/ExpediaDotCom/graphql-kotlin)
 [![codecov](https://codecov.io/gh/ExpediaDotCom/graphql-kotlin/branch/master/graph/badge.svg)](https://codecov.io/gh/ExpediaDotCom/graphql-kotlin)
 [![Maven Central](https://img.shields.io/maven-central/v/com.expedia/graphql-kotlin.svg?label=maven%20central)](https://search.maven.org/artifact/com.expedia/graphql-kotlin)
-[![Javadocs](https://www.javadoc.io/badge/com.expedia/graphql-kotlin.svg)](https://www.javadoc.io/doc/com.expedia/graphql-kotlin)
+[![Javadocs](https://img.shields.io/maven-central/v/com.expedia/graphql-kotlin.svg?label=javadoc&colorB=brightgreen)](https://www.javadoc.io/doc/com.expedia/graphql-kotlin)
 [![Awesome Kotlin Badge](https://kotlin.link/awesome-kotlin.svg)](https://github.com/KotlinBy/awesome-kotlin)
 
 Most GraphQL libraries for the JVM require developers to maintain two sources of truth for their GraphQL API, the schema and the corresponding code (data fetchers and types). Given the similarities between Kotlin and GraphQL, such as the ability to define nullable/non-nullable types, a schema should be able to be generated from Kotlin code without any separate schema specification. `graphql-kotlin` builds upon `graphql-java` to allow code-only GraphQL services to be built.


### PR DESCRIPTION
The svg is being cached so the version is out of date. [shields.io](https://shields.io) has a much better cache update so I am using the same badge as Maven Central but changes the color, text, and link

![screen shot 2019-01-03 at 10 45 29 am](https://user-images.githubusercontent.com/2446877/50655350-b1ff4480-0f44-11e9-8be3-6708a7e21959.png)


![screen shot 2019-01-03 at 10 45 56 am](https://user-images.githubusercontent.com/2446877/50655369-c3485100-0f44-11e9-8d77-b60f82d4c147.png)
