### PR TITLE
Check if query and mutation classes are public

### DIFF
--- a/example/src/main/kotlin/com/expedia/graphql/sample/model/HidesInheritance.kt
+++ b/example/src/main/kotlin/com/expedia/graphql/sample/model/HidesInheritance.kt
@@ -1,0 +1,14 @@
+package com.expedia.graphql.sample.model
+
+import com.expedia.graphql.annotations.GraphQLDescription
+
+@GraphQLDescription("Class implementing private interface that is not exposed in the schema")
+data class HidesInheritance(val id: Int) : PrivateInterface {
+
+    override val value: String
+        get() = "Implementation of a method from a private interface"
+}
+
+private interface PrivateInterface {
+    val value: String
+}

--- a/example/src/main/kotlin/com/expedia/graphql/sample/query/PrivateInterfaceQuery.kt
+++ b/example/src/main/kotlin/com/expedia/graphql/sample/query/PrivateInterfaceQuery.kt
@@ -1,0 +1,12 @@
+package com.expedia.graphql.sample.query
+
+import com.expedia.graphql.annotations.GraphQLDescription
+import com.expedia.graphql.sample.model.HidesInheritance
+import org.springframework.stereotype.Component
+
+@Component
+class PrivateInterfaceQuery : Query {
+
+    @GraphQLDescription("this query returns class implementing private interface which is not exposed in the schema")
+    fun queryForObjectWithPrivateInterface(): HidesInheritance = HidesInheritance(id = 123)
+}

--- a/src/main/kotlin/com/expedia/graphql/exceptions/InvalidMutationTypeException.kt
+++ b/src/main/kotlin/com/expedia/graphql/exceptions/InvalidMutationTypeException.kt
@@ -1,0 +1,8 @@
+package com.expedia.graphql.exceptions
+
+import kotlin.reflect.KClass
+
+/**
+ * Exception thrown on schema creation if any mutation class is not public.
+ */
+class InvalidMutationTypeException(klazz: KClass<*>) : GraphQLKotlinException("Schema requires all mutations to be public, ${klazz.simpleName} mutation has ${klazz.visibility} visibility modifier")

--- a/src/main/kotlin/com/expedia/graphql/exceptions/InvalidQueryTypeException.kt
+++ b/src/main/kotlin/com/expedia/graphql/exceptions/InvalidQueryTypeException.kt
@@ -1,0 +1,8 @@
+package com.expedia.graphql.exceptions
+
+import kotlin.reflect.KClass
+
+/**
+ * Exception thrown on schema creation if any query class is not public.
+ */
+class InvalidQueryTypeException(klazz: KClass<*>) : GraphQLKotlinException("Schema requires all queries to be public, ${klazz.simpleName} query has ${klazz.visibility} visibility modifier")

--- a/src/main/kotlin/com/expedia/graphql/exceptions/InvalidSchemaException.kt
+++ b/src/main/kotlin/com/expedia/graphql/exceptions/InvalidSchemaException.kt
@@ -1,6 +1,6 @@
 package com.expedia.graphql.exceptions
 
 /**
- * Exception thrown on schema creation if no queries and no mutations are specified.
+ * Exception thrown on schema creation if no queries are specified.
  */
 class InvalidSchemaException : GraphQLKotlinException("Schema requires at least one query")

--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/kClassExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/kClassExtensions.kt
@@ -8,6 +8,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty
+import kotlin.reflect.KVisibility
 import kotlin.reflect.full.declaredMemberFunctions
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.findParameterByName
@@ -51,3 +52,5 @@ internal fun KClass<*>.getSimpleName(isInputClass: Boolean = false): String {
 }
 
 internal fun KClass<*>.getQualifiedName(): String = this.qualifiedName ?: ""
+
+internal fun KClass<*>.isPublic(): Boolean = this.visibility == KVisibility.PUBLIC

--- a/src/main/kotlin/com/expedia/graphql/generator/types/MutationTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/MutationTypeBuilder.kt
@@ -1,9 +1,11 @@
 package com.expedia.graphql.generator.types
 
 import com.expedia.graphql.TopLevelObject
+import com.expedia.graphql.exceptions.InvalidMutationTypeException
 import com.expedia.graphql.generator.SchemaGenerator
 import com.expedia.graphql.generator.TypeBuilder
 import com.expedia.graphql.generator.extensions.getValidFunctions
+import com.expedia.graphql.generator.extensions.isPublic
 import graphql.schema.GraphQLObjectType
 
 internal class MutationTypeBuilder(generator: SchemaGenerator) : TypeBuilder(generator) {
@@ -18,6 +20,10 @@ internal class MutationTypeBuilder(generator: SchemaGenerator) : TypeBuilder(gen
         mutationBuilder.name(config.topLevelMutationName)
 
         for (mutation in mutations) {
+            if (!mutation.kClass.isPublic()) {
+                throw InvalidMutationTypeException(mutation.kClass)
+            }
+
             mutation.kClass.getValidFunctions(config.hooks)
                 .forEach {
                     val function = generator.function(it, mutation.obj)

--- a/src/main/kotlin/com/expedia/graphql/generator/types/ObjectTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/ObjectTypeBuilder.kt
@@ -7,6 +7,7 @@ import com.expedia.graphql.generator.extensions.getSimpleName
 import com.expedia.graphql.generator.extensions.getValidFunctions
 import com.expedia.graphql.generator.extensions.getValidProperties
 import com.expedia.graphql.generator.extensions.isInterface
+import com.expedia.graphql.generator.extensions.isPublic
 import com.expedia.graphql.generator.extensions.isUnion
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLObjectType
@@ -33,7 +34,7 @@ internal class ObjectTypeBuilder(generator: SchemaGenerator) : TypeBuilder(gener
             } else {
                 kClass.superclasses
                     .asSequence()
-                    .filter { it.isInterface() && !it.isUnion() }
+                    .filter { it.isPublic() && it.isInterface() && !it.isUnion() }
                     .map { objectFromReflection(it.createType(), false) as? GraphQLInterfaceType }
                     .forEach { builder.withInterface(it) }
             }

--- a/src/main/kotlin/com/expedia/graphql/generator/types/QueryTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/QueryTypeBuilder.kt
@@ -1,10 +1,12 @@
 package com.expedia.graphql.generator.types
 
 import com.expedia.graphql.TopLevelObject
+import com.expedia.graphql.exceptions.InvalidQueryTypeException
 import com.expedia.graphql.exceptions.InvalidSchemaException
 import com.expedia.graphql.generator.SchemaGenerator
 import com.expedia.graphql.generator.TypeBuilder
 import com.expedia.graphql.generator.extensions.getValidFunctions
+import com.expedia.graphql.generator.extensions.isPublic
 import graphql.schema.GraphQLObjectType
 
 internal class QueryTypeBuilder(generator: SchemaGenerator) : TypeBuilder(generator) {
@@ -20,6 +22,10 @@ internal class QueryTypeBuilder(generator: SchemaGenerator) : TypeBuilder(genera
         queryBuilder.name(config.topLevelQueryName)
 
         for (query in queries) {
+            if (!query.kClass.isPublic()) {
+                throw InvalidQueryTypeException(query.kClass)
+            }
+
             query.kClass.getValidFunctions(config.hooks)
                 .forEach {
                     val function = generator.function(it, query.obj)

--- a/src/test/kotlin/com/expedia/graphql/ToSchemaKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/ToSchemaKtTest.kt
@@ -2,9 +2,9 @@ package com.expedia.graphql
 
 import org.junit.jupiter.api.Test
 
-internal class ToSchemaKtTest {
+class ToSchemaKtTest {
 
-    internal class TestClass
+    class TestClass
 
     @Test
     fun `valid schema`() {

--- a/src/test/kotlin/com/expedia/graphql/generator/types/QueryTypeBuilderTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/QueryTypeBuilderTest.kt
@@ -3,6 +3,7 @@ package com.expedia.graphql.generator.types
 import com.expedia.graphql.TopLevelObject
 import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.annotations.GraphQLIgnore
+import com.expedia.graphql.exceptions.InvalidQueryTypeException
 import com.expedia.graphql.exceptions.InvalidSchemaException
 import com.expedia.graphql.generator.extensions.isTrue
 import com.expedia.graphql.hooks.SchemaGeneratorHooks
@@ -14,6 +15,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+@Suppress("Detekt.NestedClassesVisibility")
 internal class QueryTypeBuilderTest : TypeTestHelper() {
 
     internal class SimpleHooks : SchemaGeneratorHooks {
@@ -24,12 +26,16 @@ internal class QueryTypeBuilderTest : TypeTestHelper() {
         }
     }
 
-    internal class QueryObject {
+    private class PrivateQuery {
+        fun echo(msg: String) = msg
+    }
+
+    class QueryObject {
         @GraphQLDescription("A GraphQL query method")
         fun query(value: Int) = value
     }
 
-    internal class NoFunctions {
+    class NoFunctions {
         @GraphQLIgnore
         fun hidden(value: Int) = value
     }
@@ -45,9 +51,16 @@ internal class QueryTypeBuilderTest : TypeTestHelper() {
     }
 
     @Test
-    fun `empty list`() {
+    fun `verify builder fails if no queries are specified`() {
         assertFailsWith(InvalidSchemaException::class) {
             builder.getQueryObject(emptyList())
+        }
+    }
+
+    @Test
+    fun `verify builder fails if non public query is specified`() {
+        assertFailsWith(exceptionClass = InvalidQueryTypeException::class) {
+            builder.getQueryObject(listOf(TopLevelObject(PrivateQuery())))
         }
     }
 


### PR DESCRIPTION
Currently we are filtering non public properties and functions and don't expose them in the schema. We should have a consistent behavior for handling classes as well. With this change schema generator requires all query and mutation objects to have PUBLIC visibility modifier. Additionally, schema generator also won't include any non-public interfaces in the resulting schema.