### PR TITLE
build: travis commits the snapshot updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 .DS_Store
 target
+pom.xml.versionsBackup

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ before_install:
   - if [ ! -z "$GPG_OWNERTRUST" ]; then echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust; fi
 
 script:
-  - echo "Build library"
   - ./mvnw install
-  - echo "Verify example"
   - ./mvnw -f example/pom.xml verify
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ before_install:
   - if [ ! -z "$GPG_OWNERTRUST" ]; then echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust; fi
 
 script:
+  - echo "Build library"
   - ./mvnw install
+  - echo "Verify example"
   - ./mvnw -f example/pom.xml verify
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ deploy:
       tags: true
       jdk: oraclejdk8
 
+after_deploy:
+  - .travis/update-version.sh
+
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -x
-cd `dirname $0`/.. 
+cd `dirname $0`/..
 
 if [[ -z "$SONATYPE_USERNAME" ]]
 then
@@ -17,7 +17,7 @@ if [[ ! -z "$TRAVIS_TAG" ]]
 then
     SKIP_GPG_SIGN=false
     echo "travis tag is set -> updating pom.xml <version> attribute to $TRAVIS_TAG"
-    mvn --settings .travis/settings.xml org.codehaus.mojo:versions-maven-plugin:2.1:set -DnewVersion=$TRAVIS_TAG 1>/dev/null 2>/dev/null
+    mvn --settings .travis/settings.xml org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion=$TRAVIS_TAG 1>/dev/null 2>/dev/null
 else
     SKIP_GPG_SIGN=true
     echo "no travis tag is set, hence keeping the snapshot version in pom.xml"

--- a/.travis/update-version.sh
+++ b/.travis/update-version.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+cd `dirname $0`/..
+
+if [[ -z "$TRAVIS_TAG" ]]
+then
+    echo "ERROR! Please set TRAVIS_TAG environment variable"
+    exit 1
+fi
+
+if [[ -z "$GH_TOKEN" ]]
+then
+    echo "ERROR! Please set GH_TOKEN environment variable"
+    exit 1
+fi
+
+BRANCH_NAME=""
+
+NEW_VERSION=""
+
+setup_git
+
+update_version
+
+commit_files
+
+# Attempt to push to git only if "git commit" succeeded
+if [[ $? -eq 0 ]]; then
+  echo "Uploading to GitHub"
+  upload_files
+else
+  echo "Nothing to do"
+fi
+
+setup_git() {
+  git config --global user.email "travis@travis-ci.org"
+  git config --global user.name "Travis CI"
+}
+
+update_version() {
+
+    exampleProperty="graphql-kotlin.version"
+
+    # Push the new as tag with `-SNAPSHOT`
+    mvn --settings .travis/settings.xml org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion="${TRAVIS_TAG}-SNAPSHOT"
+
+    # Increment the patch version
+    mvn --settings .travis/settings.xml org.codehaus.mojo:versions-maven-plugin:2.7:set -DnextSnapshot=true
+
+    # Pull the number from the pom
+    NEW_VERSION=$(mvn --settings .travis/settings.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
+
+    # Update the example version
+    cd example/
+    mvn --settings ../.travis/settings.xml org.codehaus.mojo:versions-maven-plugin:2.7:set-property -Dproperty=${exampleProperty} -DnewVersion=${NEW_VERSION}
+}
+
+commit_files() {
+
+  BRANCH_NAME=${NEW_VERSION}
+
+  git checkout -b ${BRANCH_NAME}
+
+  # Stage the modified files
+  git add pom.xml example/pom.xml
+
+  # Create a new commit with a custom build message and Travis build number for reference
+  git commit -m "build: Upgrade to next snapshot (Build $TRAVIS_BUILD_NUMBER)"
+}
+
+upload_files() {
+
+  origin="https://${GH_TOKEN}@github.com/ExpediaDotCom/graphql-kotlin.git"
+
+  # Remove existing "origin"
+  git remote rm origin
+
+  # Add new "origin" with access token in the git URL for authentication
+  git remote add origin ${origin} > /dev/null 2>&1
+
+  # Push changes to the new branch
+  git push --quiet --set-upstream origin ${BRANCH_NAME}
+}
+


### PR DESCRIPTION
With this change, on every tagged build, Travis will push a new branch back to GitHub that updates the pom in the library and the example to the snapshot of `tagVersion` + 0.0.1

We need to add the token as a secret key here: https://travis-ci.org/ExpediaDotCom/graphql-kotlin/settings which requires repo admin access