### PR TITLE
feat: rename default top level names

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,17 +70,17 @@ will generate
 
 ```graphql
 schema {
-  query: TopLevelQuery
-  mutation: TopLevelMutation
+  query: Query
+  mutation: Mutation
 }
 
-type TopLevelQuery {
+type Query {
   widgetById(id: Int!): Widget
   
   widgetByValue(vale: String!): Widget @deprecated(reason: "Use widgetById")
 }
 
-type TopLevelMutation {
+type Mutation {
   saveWidget(value: String!): Widget!
 }
 

--- a/src/main/kotlin/com/expedia/graphql/SchemaGeneratorConfig.kt
+++ b/src/main/kotlin/com/expedia/graphql/SchemaGeneratorConfig.kt
@@ -9,8 +9,8 @@ import com.expedia.graphql.hooks.SchemaGeneratorHooks
  */
 data class SchemaGeneratorConfig(
     val supportedPackages: List<String>,
-    val topLevelQueryName: String = "TopLevelQuery",
-    val topLevelMutationName: String = "TopLevelMutation",
+    val topLevelQueryName: String = "Query",
+    val topLevelMutationName: String = "Mutation",
     val hooks: SchemaGeneratorHooks = NoopSchemaGeneratorHooks(),
     val dataFetcherFactoryProvider: KotlinDataFetcherFactoryProvider = KotlinDataFetcherFactoryProvider(hooks)
 )

--- a/src/test/kotlin/com/expedia/graphql/generator/DirectiveTests.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/DirectiveTests.kt
@@ -16,7 +16,7 @@ class DirectiveTests {
     @Test
     fun `SchemaGenerator marks deprecated fields in the return objects`() {
         val schema = toSchema(listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig)
-        val topLevelQuery = schema.getObjectType("TopLevelQuery")
+        val topLevelQuery = schema.getObjectType("Query")
         val query = topLevelQuery.getFieldDefinition("deprecatedFieldQuery")
         val result = (query.type as? GraphQLNonNull)?.wrappedType as? GraphQLObjectType
         val deprecatedField = result?.getFieldDefinition("deprecatedField")
@@ -28,7 +28,7 @@ class DirectiveTests {
     @Test
     fun `SchemaGenerator marks deprecated queries and documents replacement`() {
         val schema = toSchema(listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig)
-        val topLevelQuery = schema.getObjectType("TopLevelQuery")
+        val topLevelQuery = schema.getObjectType("Query")
         val query = topLevelQuery.getFieldDefinition("deprecatedQueryWithReplacement")
 
         assertTrue(query.isDeprecated)
@@ -38,7 +38,7 @@ class DirectiveTests {
     @Test
     fun `SchemaGenerator marks deprecated queries`() {
         val schema = toSchema(listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig)
-        val topLevelQuery = schema.getObjectType("TopLevelQuery")
+        val topLevelQuery = schema.getObjectType("Query")
         val query = topLevelQuery.getFieldDefinition("deprecatedQuery")
         assertTrue(query.isDeprecated)
         assertEquals("this query is deprecated", query.deprecationReason)

--- a/src/test/kotlin/com/expedia/graphql/generator/SchemaGeneratorAsyncTests.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/SchemaGeneratorAsyncTests.kt
@@ -29,7 +29,7 @@ class SchemaGeneratorAsyncTests {
     fun `SchemaGenerator strips type argument from CompletableFuture to support async servlet`() {
         val schema = toSchema(listOf(TopLevelObject(AsyncQuery())), config = testSchemaConfig)
         val returnTypeName =
-            (schema.getObjectType("TopLevelQuery").getFieldDefinition("asynchronouslyDo").type as? GraphQLNonNull)?.wrappedType?.name
+            (schema.getObjectType("Query").getFieldDefinition("asynchronouslyDo").type as? GraphQLNonNull)?.wrappedType?.name
         assertEquals("Int", returnTypeName)
     }
 
@@ -37,7 +37,7 @@ class SchemaGeneratorAsyncTests {
     fun `SchemaGenerator strips type argument from RxJava2 Observable`() {
         val schema = toSchema(listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
         val returnTypeName =
-            (schema.getObjectType("TopLevelQuery").getFieldDefinition("asynchronouslyDo").type as? GraphQLNonNull)?.wrappedType?.name
+            (schema.getObjectType("Query").getFieldDefinition("asynchronouslyDo").type as? GraphQLNonNull)?.wrappedType?.name
         assertEquals("Int", returnTypeName)
     }
 
@@ -45,7 +45,7 @@ class SchemaGeneratorAsyncTests {
     fun `SchemaGenerator strips type argument from RxJava2 Single`() {
         val schema = toSchema(listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
         val returnTypeName =
-            (schema.getObjectType("TopLevelQuery").getFieldDefinition("asynchronouslyDoSingle").type as? GraphQLNonNull)?.wrappedType?.name
+            (schema.getObjectType("Query").getFieldDefinition("asynchronouslyDoSingle").type as? GraphQLNonNull)?.wrappedType?.name
         assertEquals("Int", returnTypeName)
     }
 
@@ -53,7 +53,7 @@ class SchemaGeneratorAsyncTests {
     fun `SchemaGenerator strips type argument from RxJava2 Maybe`() {
         val schema = toSchema(listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
         val returnTypeName =
-            (schema.getObjectType("TopLevelQuery").getFieldDefinition("maybe").type as? GraphQLNonNull)?.wrappedType?.name
+            (schema.getObjectType("Query").getFieldDefinition("maybe").type as? GraphQLNonNull)?.wrappedType?.name
         assertEquals("Int", returnTypeName)
     }
 

--- a/src/test/kotlin/com/expedia/graphql/generator/SchemaGeneratorTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/SchemaGeneratorTest.kt
@@ -91,7 +91,7 @@ class SchemaGeneratorTest {
     fun `SchemaGenerator generates a GraphQL schema with repeated types to test conflicts`() {
         val schema = toSchema(listOf(TopLevelObject(QueryWithRepeatedTypes())), config = testSchemaConfig)
         val resultType = schema.getObjectType("Result")
-        val topLevelQuery = schema.getObjectType("TopLevelQuery")
+        val topLevelQuery = schema.getObjectType("Query")
         assertEquals("Result!", topLevelQuery.getFieldDefinition("query").type.deepName)
         assertEquals("SomeObject", resultType.getFieldDefinition("someObject").type.deepName)
         assertEquals("[Int!]!", resultType.getFieldDefinition("someIntValues").type.deepName)
@@ -104,7 +104,7 @@ class SchemaGeneratorTest {
     fun `SchemaGenerator generates a GraphQL schema with mixed nullity`() {
         val schema = toSchema(listOf(TopLevelObject(QueryWithNullableAndNonNullTypes())), config = testSchemaConfig)
         val resultType = schema.getObjectType("MixedNullityResult")
-        val topLevelQuery = schema.getObjectType("TopLevelQuery")
+        val topLevelQuery = schema.getObjectType("Query")
         assertEquals("MixedNullityResult!", topLevelQuery.getFieldDefinition("query").type.deepName)
         assertEquals("String", resultType.getFieldDefinition("oneThing").type.deepName)
         assertEquals("String!", resultType.getFieldDefinition("theNextThing").type.deepName)
@@ -113,7 +113,7 @@ class SchemaGeneratorTest {
     @Test
     fun `SchemaGenerator generates a GraphQL schema where the input types differ from the output types`() {
         val schema = toSchema(listOf(TopLevelObject(QueryWithInputObject())), config = testSchemaConfig)
-        val topLevelQuery = schema.getObjectType("TopLevelQuery")
+        val topLevelQuery = schema.getObjectType("Query")
         assertEquals(
             "SomeObjectInput!",
             topLevelQuery.getFieldDefinition("query").getArgument("someObject").type.deepName
@@ -124,7 +124,7 @@ class SchemaGeneratorTest {
     @Test
     fun `SchemaGenerator generates a GraphQL schema where the input and output enum is the same`() {
         val schema = toSchema(listOf(TopLevelObject(QueryWithInputEnum())), config = testSchemaConfig)
-        val topLevelQuery = schema.getObjectType("TopLevelQuery")
+        val topLevelQuery = schema.getObjectType("Query")
         assertEquals("SomeEnum!", topLevelQuery.getFieldDefinition("query").getArgument("someEnum").type.deepName)
         assertEquals("SomeEnum!", topLevelQuery.getFieldDefinition("query").type.deepName)
     }
@@ -187,7 +187,7 @@ class SchemaGeneratorTest {
     fun `SchemaGenerator ignores private fields`() {
         val schema =
             toSchema(listOf(TopLevelObject(QueryWithPrivateParts())), config = testSchemaConfig)
-        val topLevelQuery = schema.getObjectType("TopLevelQuery")
+        val topLevelQuery = schema.getObjectType("Query")
         val query = topLevelQuery.getFieldDefinition("query")
         val resultWithPrivateParts = query.type as? GraphQLObjectType
         assertNotNull(resultWithPrivateParts)

--- a/src/test/kotlin/com/expedia/graphql/hooks/SchemaGeneratorHooksTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/hooks/SchemaGeneratorHooksTest.kt
@@ -57,7 +57,7 @@ class SchemaGeneratorHooksTest {
             listOf(TopLevelObject(TestQuery())),
             config = getTestSchemaConfigWithHooks(hooks)
         )
-        val topLevelQuery = schema.getObjectType("TopLevelQuery")
+        val topLevelQuery = schema.getObjectType("Query")
         val query = topLevelQuery.getFieldDefinition("query")
         assertTrue(hooks.willGenerateGraphQLTypeCalled)
         assertEquals("InterceptedFromHook!", query.type.deepName)
@@ -145,7 +145,7 @@ class SchemaGeneratorHooksTest {
             listOf(TopLevelObject(TestQuery())),
             config = getTestSchemaConfigWithHooks(hooks)
         )
-        val topLevelQuery = schema.getObjectType("TopLevelQuery")
+        val topLevelQuery = schema.getObjectType("Query")
         val query = topLevelQuery.getFieldDefinition("query")
         assertEquals("Hijacked Description", query.description)
     }
@@ -172,7 +172,7 @@ class SchemaGeneratorHooksTest {
             mutations = listOf(TopLevelObject(TestQuery())),
             config = getTestSchemaConfigWithHooks(hooks)
         )
-        val topLevelQuery = schema.getObjectType("TopLevelMutation")
+        val topLevelQuery = schema.getObjectType("Mutation")
         val query = topLevelQuery.getFieldDefinition("query")
         assertEquals("Hijacked Description", query.description)
     }


### PR DESCRIPTION
The schema will be affected but it should not impact clients since clients are actually calling fields underneath the `Query` and `Mutation` objects