### PR TITLE
feat: do not append duplicate input suffix

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/kClassExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/kClassExtensions.kt
@@ -17,6 +17,8 @@ import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.full.superclasses
 
+private const val INPUT_SUFFIX = "Input"
+
 internal fun KClass<*>.getValidProperties(hooks: SchemaGeneratorHooks): List<KProperty<*>> =
     this.declaredMemberProperties
         .filter { hooks.isValidProperty(it) }
@@ -53,7 +55,7 @@ internal fun KClass<*>.getSimpleName(isInputClass: Boolean = false): String {
     val name = this.simpleName ?: throw CouldNotGetNameOfKClassException(this)
 
     return when {
-        isInputClass -> "${name}Input"
+        isInputClass -> if (name.endsWith(INPUT_SUFFIX)) name else "$name$INPUT_SUFFIX"
         else -> name
     }
 }

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/KClassExtensionsTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/KClassExtensionsTest.kt
@@ -32,6 +32,8 @@ open class KClassExtensionsTest {
 
     internal class MyInternalClass
 
+    class MyClassInput
+
     protected class MyProtectedClass
 
     class MyPublicClass
@@ -172,6 +174,7 @@ open class KClassExtensionsTest {
     @Test
     fun `test class simple name`() {
         assertEquals("MyTestClass", MyTestClass::class.getSimpleName())
+        assertEquals("MyClassInput", MyClassInput::class.getSimpleName())
         assertFailsWith(CouldNotGetNameOfKClassException::class) {
             object { }::class.getSimpleName()
         }

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/KClassExtensionsTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/KClassExtensionsTest.kt
@@ -174,7 +174,6 @@ open class KClassExtensionsTest {
     @Test
     fun `test class simple name`() {
         assertEquals("MyTestClass", MyTestClass::class.getSimpleName())
-        assertEquals("MyClassInput", MyClassInput::class.getSimpleName())
         assertFailsWith(CouldNotGetNameOfKClassException::class) {
             object { }::class.getSimpleName()
         }
@@ -183,6 +182,7 @@ open class KClassExtensionsTest {
     @Test
     fun `test input class name`() {
         assertEquals("MyTestClassInput", MyTestClass::class.getSimpleName(true))
+        assertEquals("MyClassInput", MyClassInput::class.getSimpleName(true))
     }
 
     @Test


### PR DESCRIPTION
If a class was named `SearchInput`, we would map that to `SearchInputInput`. If devs are specifically naming it an input we should not duplicate the string