### PR TITLE
feat: update config settings for subscriptions

### DIFF
--- a/example/src/main/kotlin/com/expedia/graphql/sample/Application.kt
+++ b/example/src/main/kotlin/com/expedia/graphql/sample/Application.kt
@@ -70,9 +70,9 @@ class Application {
         }
 
         val schema = toSchema(
-                queries = queries.toTopLevelObjectDefs(),
-                mutations = mutations.toTopLevelObjectDefs(),
-                config = schemaConfig
+            queries = queries.toTopLevelObjectDefs(),
+            mutations = mutations.toTopLevelObjectDefs(),
+            config = schemaConfig
         )
         logger.info(SchemaPrinter(
                 SchemaPrinter.Options.defaultOptions()

--- a/src/main/kotlin/com/expedia/graphql/SchemaGeneratorConfig.kt
+++ b/src/main/kotlin/com/expedia/graphql/SchemaGeneratorConfig.kt
@@ -9,8 +9,15 @@ import com.expedia.graphql.hooks.SchemaGeneratorHooks
  */
 data class SchemaGeneratorConfig(
     val supportedPackages: List<String>,
-    val topLevelQueryName: String = "Query",
-    val topLevelMutationName: String = "Mutation",
+    val topLevelNames: TopLevelNames = TopLevelNames(),
     val hooks: SchemaGeneratorHooks = NoopSchemaGeneratorHooks(),
     val dataFetcherFactoryProvider: KotlinDataFetcherFactoryProvider = KotlinDataFetcherFactoryProvider(hooks)
+)
+
+/**
+ *
+ */
+data class TopLevelNames(
+    val query: String = "Query",
+    val mutation: String = "Mutation"
 )

--- a/src/main/kotlin/com/expedia/graphql/generator/types/MutationTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/MutationTypeBuilder.kt
@@ -17,7 +17,7 @@ internal class MutationTypeBuilder(generator: SchemaGenerator) : TypeBuilder(gen
         }
 
         val mutationBuilder = GraphQLObjectType.Builder()
-        mutationBuilder.name(config.topLevelMutationName)
+        mutationBuilder.name(config.topLevelNames.mutation)
 
         for (mutation in mutations) {
             if (!mutation.kClass.isPublic()) {

--- a/src/main/kotlin/com/expedia/graphql/generator/types/QueryTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/QueryTypeBuilder.kt
@@ -19,7 +19,7 @@ internal class QueryTypeBuilder(generator: SchemaGenerator) : TypeBuilder(genera
         }
 
         val queryBuilder = GraphQLObjectType.Builder()
-        queryBuilder.name(config.topLevelQueryName)
+        queryBuilder.name(config.topLevelNames.query)
 
         for (query in queries) {
             if (!query.kClass.isPublic()) {

--- a/src/main/kotlin/com/expedia/graphql/toSchema.kt
+++ b/src/main/kotlin/com/expedia/graphql/toSchema.kt
@@ -7,17 +7,17 @@ import graphql.schema.GraphQLSchema
 /**
  * Entry point to generate a graphql schema using reflection on the passed objects.
  *
+ * @param config Schema generation configuration
  * @param queries List of [TopLevelObject] to use for GraphQL queries
  * @param mutations List of [TopLevelObject] to use for GraphQL mutations
- * @param config Schema generation configuration
  *
  * @return GraphQLSchema from graphql-java
  */
 @Throws(GraphQLKotlinException::class)
 fun toSchema(
+    config: SchemaGeneratorConfig,
     queries: List<TopLevelObject>,
-    mutations: List<TopLevelObject> = emptyList(),
-    config: SchemaGeneratorConfig
+    mutations: List<TopLevelObject> = emptyList()
 ): GraphQLSchema {
     val generator = SchemaGenerator(config)
     return generator.generate(queries, mutations)

--- a/src/test/kotlin/com/expedia/graphql/execution/CustomDataFetcherTests.kt
+++ b/src/test/kotlin/com/expedia/graphql/execution/CustomDataFetcherTests.kt
@@ -19,7 +19,7 @@ class CustomDataFetcherTests {
     @Test
     fun `Custom DataFetcher can be used on functions`() {
         val config = SchemaGeneratorConfig(supportedPackages = listOf("com.expedia"), dataFetcherFactoryProvider = CustomDataFetcherFactoryProvider())
-        val schema = toSchema(listOf(TopLevelObject(AnimalQuery())), config = config)
+        val schema = toSchema(queries = listOf(TopLevelObject(AnimalQuery())), config = config)
 
         val animalType = schema.getObjectType("Animal")
         assertEquals("AnimalDetails!", animalType.getFieldDefinition("details").type.deepName)

--- a/src/test/kotlin/com/expedia/graphql/execution/DataFetchPredicateTests.kt
+++ b/src/test/kotlin/com/expedia/graphql/execution/DataFetchPredicateTests.kt
@@ -19,8 +19,8 @@ class DataFetchPredicateTests {
     fun `A datafetcher execution is stopped if the predicate test is false`() {
         val config = getTestSchemaConfigWithHooks(PredicateHooks())
         val schema = toSchema(
-                listOf(TopLevelObject(QueryWithValidations())),
-                config = config
+            queries = listOf(TopLevelObject(QueryWithValidations())),
+            config = config
         )
         val graphQL = GraphQL.newGraphQL(schema).build()
         val result = graphQL.execute("{ greaterThan2Times10(greaterThan2: 1) }")
@@ -36,8 +36,8 @@ class DataFetchPredicateTests {
     fun `A datafetcher execution is stopped if the predicate test is false with complex argument under test`() {
         val config = getTestSchemaConfigWithHooks(PredicateHooks())
         val schema = toSchema(
-                listOf(TopLevelObject(QueryWithValidations())),
-                config = config
+            queries = listOf(TopLevelObject(QueryWithValidations())),
+            config = config
         )
         val graphQL = GraphQL.newGraphQL(schema).build()
         val result = graphQL.execute("{ complexPredicate(person: { age: 33, name: \"Alice\"}) }")

--- a/src/test/kotlin/com/expedia/graphql/generator/DirectiveTests.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/DirectiveTests.kt
@@ -15,7 +15,7 @@ import kotlin.test.assertTrue
 class DirectiveTests {
     @Test
     fun `SchemaGenerator marks deprecated fields in the return objects`() {
-        val schema = toSchema(listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig)
         val topLevelQuery = schema.getObjectType("Query")
         val query = topLevelQuery.getFieldDefinition("deprecatedFieldQuery")
         val result = (query.type as? GraphQLNonNull)?.wrappedType as? GraphQLObjectType
@@ -27,7 +27,7 @@ class DirectiveTests {
 
     @Test
     fun `SchemaGenerator marks deprecated queries and documents replacement`() {
-        val schema = toSchema(listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig)
         val topLevelQuery = schema.getObjectType("Query")
         val query = topLevelQuery.getFieldDefinition("deprecatedQueryWithReplacement")
 
@@ -37,7 +37,7 @@ class DirectiveTests {
 
     @Test
     fun `SchemaGenerator marks deprecated queries`() {
-        val schema = toSchema(listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithDeprecatedFields())), config = testSchemaConfig)
         val topLevelQuery = schema.getObjectType("Query")
         val query = topLevelQuery.getFieldDefinition("deprecatedQuery")
         assertTrue(query.isDeprecated)
@@ -46,7 +46,7 @@ class DirectiveTests {
 
     @Test
     fun `Default directive names are normalized`() {
-        val schema = toSchema(listOf(TopLevelObject(QueryObject())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryObject())), config = testSchemaConfig)
 
         val query = schema.queryType.getFieldDefinition("query")
         assertNotNull(query)
@@ -55,7 +55,7 @@ class DirectiveTests {
 
     @Test
     fun `Custom directive names are not modified`() {
-        val schema = toSchema(listOf(TopLevelObject(QueryObject())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryObject())), config = testSchemaConfig)
 
         val directive = assertNotNull(
                 (schema.getType("Location") as? GraphQLObjectType)

--- a/src/test/kotlin/com/expedia/graphql/generator/PolymorphicTests.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/PolymorphicTests.kt
@@ -16,7 +16,7 @@ internal class PolymorphicTests {
 
     @Test
     fun `Schema generator creates union types from marked up interface`() {
-        val schema = toSchema(listOf(TopLevelObject(QueryWithUnion())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithUnion())), config = testSchemaConfig)
 
         val graphqlType = schema.getType("BodyPart") as? GraphQLUnionType
         assertNotNull(graphqlType)
@@ -33,7 +33,7 @@ internal class PolymorphicTests {
 
     @Test
     fun `SchemaGenerator can expose an interface and its implementations`() {
-        val schema = toSchema(listOf(TopLevelObject(QueryWithInterface())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithInterface())), config = testSchemaConfig)
 
         val interfaceType = schema.getType("AnInterface")
         assertNotNull(interfaceType)
@@ -47,20 +47,20 @@ internal class PolymorphicTests {
     @Test
     fun `Interfaces cannot be used as input field types`() {
         assertThrows(InvalidInputFieldTypeException::class.java) {
-            toSchema(listOf(TopLevelObject(QueryWithUnAuthorizedInterfaceArgument())), config = testSchemaConfig)
+            toSchema(queries = listOf(TopLevelObject(QueryWithUnAuthorizedInterfaceArgument())), config = testSchemaConfig)
         }
     }
 
     @Test
     fun `Union cannot be used as input field types`() {
         assertThrows(InvalidInputFieldTypeException::class.java) {
-            toSchema(listOf(TopLevelObject(QueryWithUnAuthorizedUnionArgument())), config = testSchemaConfig)
+            toSchema(queries = listOf(TopLevelObject(QueryWithUnAuthorizedUnionArgument())), config = testSchemaConfig)
         }
     }
 
     @Test
     fun `Object types implementing union and interfaces are only created once`() {
-        val schema = toSchema(listOf(TopLevelObject(QueryWithInterfaceAnUnion())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithInterfaceAnUnion())), config = testSchemaConfig)
 
         val carType = schema.getType("Car") as? GraphQLObjectType
         assertNotNull(carType)
@@ -74,7 +74,7 @@ internal class PolymorphicTests {
 
     @Test
     fun `Interfaces can declare properties of their own type`() {
-        val schema = toSchema(listOf(TopLevelObject(QueryWithRecursiveType())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithRecursiveType())), config = testSchemaConfig)
 
         val personType = schema.getType("Person")
         assertNotNull(personType)

--- a/src/test/kotlin/com/expedia/graphql/generator/SchemaGeneratorAsyncTests.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/SchemaGeneratorAsyncTests.kt
@@ -27,7 +27,7 @@ class SchemaGeneratorAsyncTests {
 
     @Test
     fun `SchemaGenerator strips type argument from CompletableFuture to support async servlet`() {
-        val schema = toSchema(listOf(TopLevelObject(AsyncQuery())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(AsyncQuery())), config = testSchemaConfig)
         val returnTypeName =
             (schema.getObjectType("Query").getFieldDefinition("asynchronouslyDo").type as? GraphQLNonNull)?.wrappedType?.name
         assertEquals("Int", returnTypeName)
@@ -35,7 +35,7 @@ class SchemaGeneratorAsyncTests {
 
     @Test
     fun `SchemaGenerator strips type argument from RxJava2 Observable`() {
-        val schema = toSchema(listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
+        val schema = toSchema(queries = listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
         val returnTypeName =
             (schema.getObjectType("Query").getFieldDefinition("asynchronouslyDo").type as? GraphQLNonNull)?.wrappedType?.name
         assertEquals("Int", returnTypeName)
@@ -43,7 +43,7 @@ class SchemaGeneratorAsyncTests {
 
     @Test
     fun `SchemaGenerator strips type argument from RxJava2 Single`() {
-        val schema = toSchema(listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
+        val schema = toSchema(queries = listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
         val returnTypeName =
             (schema.getObjectType("Query").getFieldDefinition("asynchronouslyDoSingle").type as? GraphQLNonNull)?.wrappedType?.name
         assertEquals("Int", returnTypeName)
@@ -51,7 +51,7 @@ class SchemaGeneratorAsyncTests {
 
     @Test
     fun `SchemaGenerator strips type argument from RxJava2 Maybe`() {
-        val schema = toSchema(listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
+        val schema = toSchema(queries = listOf(TopLevelObject(RxJava2Query())), config = configWithRxJavaMonads)
         val returnTypeName =
             (schema.getObjectType("Query").getFieldDefinition("maybe").type as? GraphQLNonNull)?.wrappedType?.name
         assertEquals("Int", returnTypeName)

--- a/src/test/kotlin/com/expedia/graphql/generator/SchemaGeneratorTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/SchemaGeneratorTest.kt
@@ -31,8 +31,8 @@ class SchemaGeneratorTest {
     @Test
     fun `SchemaGenerator generates a simple GraphQL schema`() {
         val schema = toSchema(
-            listOf(TopLevelObject(QueryObject())),
-            listOf(TopLevelObject(MutationObject())),
+            queries = listOf(TopLevelObject(QueryObject())),
+            mutations = listOf(TopLevelObject(MutationObject())),
             config = testSchemaConfig
         )
         val graphQL = GraphQL.newGraphQL(schema).build()
@@ -45,7 +45,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `Schema generator exposes arrays of primitive types as function arguments`() {
-        val schema = toSchema(listOf(TopLevelObject(QueryWithArray())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithArray())), config = testSchemaConfig)
         val firstArgumentType = schema.queryType.getFieldDefinition("sumOf").arguments[0].type.deepName
         assertEquals("[Int!]!", firstArgumentType)
 
@@ -58,7 +58,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `Schema generator exposes arrays of complex types as function arguments`() {
-        val schema = toSchema(listOf(TopLevelObject(QueryWithArray())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithArray())), config = testSchemaConfig)
         val firstArgumentType = schema.queryType.getFieldDefinition("sumOfComplexArray").arguments[0].type.deepName
         assertEquals("[ComplexWrappingTypeInput!]!", firstArgumentType)
 
@@ -71,7 +71,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `SchemaGenerator ignores fields and functions with @Ignore`() {
-        val schema = toSchema(listOf(TopLevelObject(QueryWithIgnored())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithIgnored())), config = testSchemaConfig)
 
         assertTrue(schema.queryType.fieldDefinitions.none {
             it.name == "ignoredFunction"
@@ -89,7 +89,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `SchemaGenerator generates a GraphQL schema with repeated types to test conflicts`() {
-        val schema = toSchema(listOf(TopLevelObject(QueryWithRepeatedTypes())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithRepeatedTypes())), config = testSchemaConfig)
         val resultType = schema.getObjectType("Result")
         val topLevelQuery = schema.getObjectType("Query")
         assertEquals("Result!", topLevelQuery.getFieldDefinition("query").type.deepName)
@@ -102,7 +102,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `SchemaGenerator generates a GraphQL schema with mixed nullity`() {
-        val schema = toSchema(listOf(TopLevelObject(QueryWithNullableAndNonNullTypes())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithNullableAndNonNullTypes())), config = testSchemaConfig)
         val resultType = schema.getObjectType("MixedNullityResult")
         val topLevelQuery = schema.getObjectType("Query")
         assertEquals("MixedNullityResult!", topLevelQuery.getFieldDefinition("query").type.deepName)
@@ -112,7 +112,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `SchemaGenerator generates a GraphQL schema where the input types differ from the output types`() {
-        val schema = toSchema(listOf(TopLevelObject(QueryWithInputObject())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithInputObject())), config = testSchemaConfig)
         val topLevelQuery = schema.getObjectType("Query")
         assertEquals(
             "SomeObjectInput!",
@@ -123,7 +123,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `SchemaGenerator generates a GraphQL schema where the input and output enum is the same`() {
-        val schema = toSchema(listOf(TopLevelObject(QueryWithInputEnum())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithInputEnum())), config = testSchemaConfig)
         val topLevelQuery = schema.getObjectType("Query")
         assertEquals("SomeEnum!", topLevelQuery.getFieldDefinition("query").getArgument("someEnum").type.deepName)
         assertEquals("SomeEnum!", topLevelQuery.getFieldDefinition("query").type.deepName)
@@ -132,8 +132,8 @@ class SchemaGeneratorTest {
     @Test
     fun `SchemaGenerator documents types annotated with @Description`() {
         val schema = toSchema(
-            listOf(TopLevelObject(QueryObject())),
-            listOf(TopLevelObject(MutationObject())),
+            queries = listOf(TopLevelObject(QueryObject())),
+            mutations = listOf(TopLevelObject(MutationObject())),
             config = testSchemaConfig
         )
         val geo = schema.getObjectType("Geography")
@@ -143,8 +143,8 @@ class SchemaGeneratorTest {
     @Test
     fun `SchemaGenerator documents arguments annotated with @Description`() {
         val schema = toSchema(
-            listOf(TopLevelObject(QueryObject())),
-            listOf(TopLevelObject(MutationObject())),
+            queries = listOf(TopLevelObject(QueryObject())),
+            mutations = listOf(TopLevelObject(MutationObject())),
             config = testSchemaConfig
         )
         val documentation = schema.queryType.fieldDefinitions.first().arguments.first().description
@@ -154,8 +154,8 @@ class SchemaGeneratorTest {
     @Test
     fun `SchemaGenerator documents properties annotated with @Description`() {
         val schema = toSchema(
-            listOf(TopLevelObject(QueryObject())),
-            listOf(TopLevelObject(MutationObject())),
+            queries = listOf(TopLevelObject(QueryObject())),
+            mutations = listOf(TopLevelObject(MutationObject())),
             config = testSchemaConfig
         )
         val documentation = schema.queryType.fieldDefinitions.first().description
@@ -164,7 +164,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `SchemaGenerator can expose functions on result classes`() {
-        val schema = toSchema(listOf(TopLevelObject(QueryWithDataThatContainsFunction())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithDataThatContainsFunction())), config = testSchemaConfig)
         val resultWithFunction = schema.getObjectType("ResultWithFunction")
         val repeatFieldDefinition = resultWithFunction.getFieldDefinition("repeat")
         assertEquals("repeat", repeatFieldDefinition.name)
@@ -175,7 +175,7 @@ class SchemaGeneratorTest {
 
     @Test
     fun `SchemaGenerator can execute functions on result classes`() {
-        val schema = toSchema(listOf(TopLevelObject(QueryWithDataThatContainsFunction())), config = testSchemaConfig)
+        val schema = toSchema(queries = listOf(TopLevelObject(QueryWithDataThatContainsFunction())), config = testSchemaConfig)
         val graphQL = GraphQL.newGraphQL(schema).build()
         val result = graphQL.execute("{ query(something: \"thing\") { repeat(n: 3) } }")
         val data: Map<String, Map<String, Any>> = result.getData()
@@ -186,7 +186,7 @@ class SchemaGeneratorTest {
     @Test
     fun `SchemaGenerator ignores private fields`() {
         val schema =
-            toSchema(listOf(TopLevelObject(QueryWithPrivateParts())), config = testSchemaConfig)
+            toSchema(queries = listOf(TopLevelObject(QueryWithPrivateParts())), config = testSchemaConfig)
         val topLevelQuery = schema.getObjectType("Query")
         val query = topLevelQuery.getFieldDefinition("query")
         val resultWithPrivateParts = query.type as? GraphQLObjectType
@@ -199,14 +199,14 @@ class SchemaGeneratorTest {
     @Test
     fun `SchemaGenerator throws when encountering java stdlib`() {
         assertFailsWith(GraphQLKotlinException::class) {
-            toSchema(listOf(TopLevelObject(QueryWithJavaClass())), config = testSchemaConfig)
+            toSchema(queries = listOf(TopLevelObject(QueryWithJavaClass())), config = testSchemaConfig)
         }
     }
 
     @Test
     fun `SchemaGenerator throws when encountering list of java stdlib`() {
         assertFailsWith(GraphQLKotlinException::class) {
-            toSchema(listOf(TopLevelObject(QueryWithListOfJavaClass())), config = testSchemaConfig)
+            toSchema(queries = listOf(TopLevelObject(QueryWithListOfJavaClass())), config = testSchemaConfig)
         }
     }
 

--- a/src/test/kotlin/com/expedia/graphql/generator/types/TypeTestHelper.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/TypeTestHelper.kt
@@ -49,8 +49,8 @@ internal open class TypeTestHelper {
         every { generator.subTypeMapper } returns subTypeMapper
         every { config.hooks } returns hooks
         every { config.dataFetcherFactoryProvider } returns dataFetcherFactory
-        every { config.topLevelQueryName } returns "TestTopLevelQuery"
-        every { config.topLevelMutationName } returns "TestTopLevelMutation"
+
+        every { config.topLevelNames } returns com.expedia.graphql.TopLevelNames(query = "TestTopLevelQuery", mutation = "TestTopLevelMutation")
 
         functionTypeBuilder = spyk(FunctionTypeBuilder(generator))
         every { generator.function(any(), any(), any()) } answers {

--- a/src/test/kotlin/com/expedia/graphql/hooks/SchemaGeneratorHooksTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/hooks/SchemaGeneratorHooksTest.kt
@@ -35,7 +35,7 @@ class SchemaGeneratorHooksTest {
 
         val hooks = MockSchemaGeneratorHooks()
         val schema = toSchema(
-            listOf(TopLevelObject(TestQuery())),
+            queries = listOf(TopLevelObject(TestQuery())),
             config = getTestSchemaConfigWithHooks(hooks)
         )
         assertTrue(hooks.willBuildSchemaCalled)
@@ -54,7 +54,7 @@ class SchemaGeneratorHooksTest {
 
         val hooks = MockSchemaGeneratorHooks()
         val schema = toSchema(
-            listOf(TopLevelObject(TestQuery())),
+            queries = listOf(TopLevelObject(TestQuery())),
             config = getTestSchemaConfigWithHooks(hooks)
         )
         val topLevelQuery = schema.getObjectType("Query")
@@ -76,7 +76,7 @@ class SchemaGeneratorHooksTest {
 
         val hooks = MockSchemaGeneratorHooks()
         val schema = toSchema(
-            listOf(TopLevelObject(TestQuery())),
+            queries = listOf(TopLevelObject(TestQuery())),
             config = getTestSchemaConfigWithHooks(hooks)
         )
         assertTrue(hooks.calledFilterFunction)
@@ -97,7 +97,7 @@ class SchemaGeneratorHooksTest {
 
         val hooks = MockSchemaGeneratorHooks()
         val schema = toSchema(
-            listOf(TopLevelObject(TestQuery())),
+            queries = listOf(TopLevelObject(TestQuery())),
             config = getTestSchemaConfigWithHooks(hooks)
         )
         assertTrue(hooks.calledFilterFunction)
@@ -117,7 +117,7 @@ class SchemaGeneratorHooksTest {
 
         val hooks = MockSchemaGeneratorHooks()
         toSchema(
-            listOf(TopLevelObject(TestQuery())),
+            queries = listOf(TopLevelObject(TestQuery())),
             config = getTestSchemaConfigWithHooks(hooks)
         )
         assertEquals(SomeData::class.createType(), hooks.lastSeenType)
@@ -142,7 +142,7 @@ class SchemaGeneratorHooksTest {
 
         val hooks = MockSchemaGeneratorHooks()
         val schema = toSchema(
-            listOf(TopLevelObject(TestQuery())),
+            queries = listOf(TopLevelObject(TestQuery())),
             config = getTestSchemaConfigWithHooks(hooks)
         )
         val topLevelQuery = schema.getObjectType("Query")

--- a/src/test/kotlin/com/expedia/graphql/integration/OptionalResultsTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/integration/OptionalResultsTest.kt
@@ -13,8 +13,8 @@ class OptionalResultsTest {
     @Test
     fun `SchemaGenerator generates a simple GraphQL schema`() {
         val schema = toSchema(
-            listOf(TopLevelObject(QueryObject())),
-            listOf(),
+            queries = listOf(TopLevelObject(QueryObject())),
+            mutations = listOf(),
             config = testSchemaConfig
         )
         val graphQL = GraphQL.newGraphQL(schema).build()


### PR DESCRIPTION
To prepare for subscriptions, I moved the order of the parameters in `toSchema()` so that `config` is first. This will allow us to easily add subscriptions as the optional final parameter. Also since we will have another option for a top level name I combined all the names into a single object