### PR TITLE
feat: log a better exception on invalid argument types

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotCastArgumentException.kt
+++ b/src/main/kotlin/com/expedia/graphql/exceptions/CouldNotCastArgumentException.kt
@@ -1,0 +1,6 @@
+package com.expedia.graphql.exceptions
+
+import kotlin.reflect.KParameter
+
+class CouldNotCastArgumentException(kParameter: KParameter)
+    : GraphQLKotlinException("Could not cast or map arguments in the data fetcher for $kParameter")

--- a/src/main/kotlin/com/expedia/graphql/exceptions/InvalidInputFieldTypeException.kt
+++ b/src/main/kotlin/com/expedia/graphql/exceptions/InvalidInputFieldTypeException.kt
@@ -1,5 +1,7 @@
 package com.expedia.graphql.exceptions
 
+import kotlin.reflect.KParameter
+
 /**
  * GraphQL Interfaces and Unions cannot be used as arguments.
  * Specification reference: https://facebook.github.io/graphql/draft/#sec-Field-Arguments
@@ -28,4 +30,5 @@ package com.expedia.graphql.exceptions
  *
  * data class PartOfUnion( val property: Int) : UnionMarkup
  */
-class InvalidInputFieldTypeException : GraphQLKotlinException("Object field argument cannot be an interface or a union")
+class InvalidInputFieldTypeException(kParameter: KParameter)
+    : GraphQLKotlinException("Argument cannot be an interface or a union, $kParameter")

--- a/src/main/kotlin/com/expedia/graphql/execution/FunctionDataFetcher.kt
+++ b/src/main/kotlin/com/expedia/graphql/execution/FunctionDataFetcher.kt
@@ -36,7 +36,9 @@ class FunctionDataFetcher(
         val instance = target ?: environment.getSource<Any>()
 
         return instance?.let {
-            val parameterValues = fn.valueParameters.map { param -> mapParameterToValue(param, environment) }.toTypedArray()
+            val parameterValues = fn.valueParameters
+                .map { param -> mapParameterToValue(param, environment) }
+                .toTypedArray()
 
             if (fn.isSuspend) {
                 GlobalScope.async {
@@ -53,7 +55,7 @@ class FunctionDataFetcher(
             environment.getContext()
         } else {
             val name = param.getName()
-            val klazz = param.type.javaTypeClass
+            val klazz = param.javaTypeClass()
             val value = objectMapper.convertValue(environment.arguments[name], klazz)
             val predicateResult = executionPredicate?.evaluate(value = value, parameter = param, environment = environment)
 

--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/suppressedExtenstions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/suppressedExtenstions.kt
@@ -1,8 +1,8 @@
 package com.expedia.graphql.generator.extensions
 
-import kotlin.reflect.KType
+import com.expedia.graphql.exceptions.CouldNotCastArgumentException
+import kotlin.reflect.KParameter
 import kotlin.reflect.jvm.javaType
 
-@Suppress("Detekt.UnsafeCast")
-internal val KType.javaTypeClass: Class<*>
-    get() = this.javaType as Class<*>
+@Throws(CouldNotCastArgumentException::class)
+internal fun KParameter.javaTypeClass(): Class<*> = this.type.javaType as? Class<*> ?: throw CouldNotCastArgumentException(this)

--- a/src/main/kotlin/com/expedia/graphql/generator/types/FunctionTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/FunctionTypeBuilder.kt
@@ -53,7 +53,7 @@ internal class FunctionTypeBuilder(generator: SchemaGenerator) : TypeBuilder(gen
     private fun argument(parameter: KParameter): GraphQLArgument {
 
         if (parameter.isInterface()) {
-            throw InvalidInputFieldTypeException()
+            throw InvalidInputFieldTypeException(parameter)
         }
 
         val builder = GraphQLArgument.newArgument()

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/KParameterExtensionsKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/KParameterExtensionsKtTest.kt
@@ -9,14 +9,23 @@ import kotlin.reflect.KParameter
 import kotlin.reflect.full.findParameterByName
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 internal class KParameterExtensionsKtTest {
 
     @GraphQLDescription("class description")
     internal data class MyClass(val foo: String)
 
+    internal interface MyInterface {
+        val value: String
+    }
+
     internal class Container {
+
+        internal fun interfaceInput(myInterface: MyInterface) = myInterface
+
         internal fun noDescription(myClass: MyClass) = myClass
 
         internal fun paramDescription(@GraphQLDescription("param description") myClass: MyClass) = myClass
@@ -47,5 +56,17 @@ internal class KParameterExtensionsKtTest {
     fun `no description`() {
         val param = Container::noDescription.findParameterByName("myClass")
         assertNull(param?.getGraphQLDescription())
+    }
+
+    @Test
+    fun `class input is invalid`() {
+        val param = Container::noDescription.findParameterByName("myClass")
+        assertFalse(param?.isInterface().isTrue())
+    }
+
+    @Test
+    fun `interface input is invalid`() {
+        val param = Container::interfaceInput.findParameterByName("myInterface")
+        assertTrue(param?.isInterface().isTrue())
     }
 }

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/SuppressedExtenstionsKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/SuppressedExtenstionsKtTest.kt
@@ -1,6 +1,7 @@
 package com.expedia.graphql.generator.extensions
 
 import org.junit.jupiter.api.Test
+import kotlin.reflect.full.findParameterByName
 import kotlin.test.assertEquals
 
 internal class SuppressedExtenstionsKtTest {
@@ -11,6 +12,6 @@ internal class SuppressedExtenstionsKtTest {
 
     @Test
     fun javaTypeClass() {
-        assertEquals(expected = String::class.java, actual = MyClass::stringFun.returnType.javaTypeClass)
+        assertEquals(expected = String::class.java, actual = MyClass::stringFun.findParameterByName("string")?.javaTypeClass())
     }
 }


### PR DESCRIPTION
The new exception reads as following

```
com.expedia.graphql.exceptions.CouldNotCastArgumentException: Could not cast or map arguments in the data fetcher for parameter #1 items of fun com.expedia.graphql.execution.FunctionDataFetcherTest.MyClass.printList(kotlin.collections.List<kotlin.String>): kotlin.String

```

Also I added unit tests for the function data fetcher