### PR TITLE
fix: move the default handling of CompletableFuture

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/hooks/SchemaGeneratorHooks.kt
+++ b/src/main/kotlin/com/expedia/graphql/hooks/SchemaGeneratorHooks.kt
@@ -1,11 +1,9 @@
 package com.expedia.graphql.hooks
 
 import com.expedia.graphql.execution.DataFetcherExecutionPredicate
-import com.expedia.graphql.generator.extensions.getTypeOfFirstArgument
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLType
-import java.util.concurrent.CompletableFuture
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty
@@ -31,15 +29,10 @@ interface SchemaGeneratorHooks {
     fun willGenerateGraphQLType(type: KType): GraphQLType? = null
 
     /**
-     * Called before resolving a Monad or Future type to its wrapped KType.
-     * This allows for a custom resolver on how to extract the wrapped value.
+     * Called before resolving a KType to the GraphQL type.
+     * This allows for a custom resolver on how to extract wrapped values, like in a CompletableFuture.
      */
-    fun willResolveMonad(type: KType): KType =
-        if (type.classifier == CompletableFuture::class) {
-            type.getTypeOfFirstArgument()
-        } else {
-            type
-        }
+    fun willResolveMonad(type: KType): KType = type
 
     /**
      * Called when looking at the KClass superclasses to determine if it valid for adding to the generated schema.

--- a/src/test/kotlin/com/expedia/graphql/generator/types/FunctionTypeBuilderTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/FunctionTypeBuilderTest.kt
@@ -1,14 +1,15 @@
 package com.expedia.graphql.generator.types
 
-import com.expedia.graphql.execution.FunctionDataFetcher
 import com.expedia.graphql.annotations.GraphQLContext
 import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.annotations.GraphQLDirective
+import com.expedia.graphql.execution.FunctionDataFetcher
 import graphql.Scalars
 import graphql.introspection.Introspection
 import graphql.schema.GraphQLNonNull
 import org.junit.jupiter.api.Test
 import java.util.UUID
+import java.util.concurrent.CompletableFuture
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -49,6 +50,8 @@ internal class FunctionTypeBuilderTest : TypeTestHelper() {
         fun saw(tree: String) = tree
 
         fun context(@GraphQLContext context: String, string: String) = "$context and $string"
+
+        fun completableFuture(num: Int): CompletableFuture<Int> = CompletableFuture.completedFuture(num)
     }
 
     @Test
@@ -147,5 +150,14 @@ internal class FunctionTypeBuilderTest : TypeTestHelper() {
 
         assertEquals(expected = 1, actual = result.arguments.size)
         assertFalse(result.dataFetcher is FunctionDataFetcher)
+    }
+
+    @Test
+    fun `completable future return type is valid`() {
+        val kFunction = Happy::completableFuture
+        val result = builder.function(fn = kFunction)
+
+        assertEquals(expected = 1, actual = result.arguments.size)
+        assertEquals("Int", (result.type as? GraphQLNonNull)?.wrappedType?.name)
     }
 }

--- a/src/test/kotlin/com/expedia/graphql/hooks/SchemaGeneratorHooksTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/hooks/SchemaGeneratorHooksTest.kt
@@ -9,7 +9,6 @@ import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLType
-import java.util.concurrent.CompletableFuture
 import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
@@ -178,14 +177,6 @@ class SchemaGeneratorHooksTest {
     }
 
     @Test
-    fun `willResolveMonad returns CompletableFuture wrapped type`() {
-        val hooks = NoopSchemaGeneratorHooks()
-        val type = TestQueryFuture::comepletableFutre.returnType
-
-        assertEquals(expected = "SomeData", actual = hooks.willResolveMonad(type).getSimpleName())
-    }
-
-    @Test
     fun `willResolveMonad returns basic type`() {
         val hooks = NoopSchemaGeneratorHooks()
         val type = TestQuery::query.returnType
@@ -195,10 +186,6 @@ class SchemaGeneratorHooksTest {
 
     class TestQuery {
         fun query(): SomeData = SomeData(0)
-    }
-
-    class TestQueryFuture {
-        fun comepletableFutre(): CompletableFuture<SomeData> = CompletableFuture.completedFuture(SomeData(1))
     }
 
     data class SomeData(val someNumber: Int)


### PR DESCRIPTION
This will have no impact on existing clients. I just moved the handling of `CompletableFuture`s into the code so that it will always happen. Right now, clients need to remember to still handle `CompletableFuture`s if they override the hook.

We now resolve the type from the hook first, which defaults to the same type. Then we check after if it is on of the default supported wrapped types, which right now only includes `CompletableFuture`, but will extend to `Publisher` when we support subscriptions