### PR TITLE
fix: remove directive duplication in the generator

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/generator/types/DirectiveTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/DirectiveTypeBuilder.kt
@@ -20,6 +20,12 @@ internal class DirectiveTypeBuilder(generator: SchemaGenerator) : TypeBuilder(ge
 
     private fun getDirective(directiveInfo: DirectiveInfo): GraphQLDirective {
 
+        val existingDirective = state.directives.find { it.name == directiveInfo.effectiveName }
+
+        if (existingDirective != null) {
+            return existingDirective
+        }
+
         val directiveClass = directiveInfo.directive.annotationClass
 
         val builder = GraphQLDirective.newDirective()

--- a/src/test/kotlin/com/expedia/graphql/generator/types/DirectiveTypeBuilderTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/DirectiveTypeBuilderTest.kt
@@ -79,4 +79,11 @@ internal class DirectiveTypeBuilderTest {
     fun `has directive with class`() {
         assertEquals(expected = 1, actual = basicGenerator.directives(MyClass::directiveWithClass).size)
     }
+
+    @Test
+    fun `directives are not duplicated in the schema`() {
+        basicGenerator.directives(MyClass::simpleDirective)
+        basicGenerator.directives(MyClass::simpleDirective)
+        assertEquals(1, basicGenerator.state.directives.size)
+    }
 }


### PR DESCRIPTION
Before:
<img width="968" alt="screen shot 2019-02-25 at 12 03 29 am" src="https://user-images.githubusercontent.com/2446877/53322616-c3076a80-3890-11e9-80d3-f846f50f57a7.png">


After: 
<img width="963" alt="screen shot 2019-02-25 at 12 00 02 am" src="https://user-images.githubusercontent.com/2446877/53322571-a23f1500-3890-11e9-9dd7-93c16c37f0c4.png">
