### PR TITLE
fix: travis deployments are not running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,7 @@ deploy:
     on:
       repo: ExpediaDotCom/graphql-kotlin
       branch: master
-      jdk:
-        - openjdk8
-        - openjdk11
+      jdk: openjdk8
   -
     provider: script
     script: .travis/deploy.sh
@@ -35,9 +33,7 @@ deploy:
     on:
       repo: ExpediaDotCom/graphql-kotlin
       tags: true
-      jdk:
-        - openjdk8
-        - openjdk11
+      jdk: openjdk8
 
 after_deploy:
   - .travis/update-version.sh


### PR DESCRIPTION
It looks like the conditional for `deployment.on.jdk` is a single version not an array. This would make sense if we don't want both jobs to publish a jar

https://docs.travis-ci.com/user/deployment#conditional-releases-with-on