### PR TITLE
build: don't run deploy on master branch push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,22 +18,13 @@ script:
   - ./mvnw -f example/pom.xml verify
 
 deploy:
-  -
-    provider: script
-    script: .travis/deploy.sh
-    skip_cleanup: true
-    on:
-      repo: ExpediaDotCom/graphql-kotlin
-      branch: master
-      jdk: openjdk8
-  -
-    provider: script
-    script: .travis/deploy.sh
-    skip_cleanup: true
-    on:
-      repo: ExpediaDotCom/graphql-kotlin
-      tags: true
-      jdk: openjdk8
+  provider: script
+  script: .travis/deploy.sh
+  skip_cleanup: true
+  on:
+    repo: ExpediaDotCom/graphql-kotlin
+    tags: true
+    jdk: openjdk8
 
 after_deploy:
   - .travis/update-version.sh


### PR DESCRIPTION
We could use this if we wanted to publish snapshots but we are not doing that anyway right now because our deploy script checks to see if there is `TRAVIS_TAG` so it never runs on master pushes