### PR TITLE
fix: add directives on enum values

### DIFF
--- a/example/src/main/kotlin/com/expedia/graphql/sample/model/Animal.kt
+++ b/example/src/main/kotlin/com/expedia/graphql/sample/model/Animal.kt
@@ -1,6 +1,7 @@
 package com.expedia.graphql.sample.model
 
 import com.expedia.graphql.annotations.GraphQLDescription
+import com.expedia.graphql.sample.directives.SimpleDirective
 
 @GraphQLDescription("animal interface type")
 interface Animal {
@@ -12,8 +13,10 @@ interface Animal {
 }
 
 @GraphQLDescription("enum holding all supported animal types")
+@SimpleDirective
 enum class AnimalType {
     CAT,
+    @SimpleDirective
     DOG
 }
 

--- a/src/main/kotlin/com/expedia/graphql/generator/SchemaGenerator.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/SchemaGenerator.kt
@@ -18,6 +18,7 @@ import com.expedia.graphql.generator.types.UnionTypeBuilder
 import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLSchema
+import java.lang.reflect.Field
 import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
@@ -85,6 +86,12 @@ internal class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
 
     internal fun directives(element: KAnnotatedElement): List<GraphQLDirective> {
         val directives = directiveTypeBuilder.directives(element)
+        state.directives.addAll(directives)
+        return directives
+    }
+
+    internal fun fieldDirectives(field: Field): List<GraphQLDirective> {
+        val directives = directiveTypeBuilder.fieldDirectives(field)
         state.directives.addAll(directives)
         return directives
     }

--- a/src/main/kotlin/com/expedia/graphql/generator/types/DirectiveTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/DirectiveTypeBuilder.kt
@@ -8,6 +8,7 @@ import com.expedia.graphql.generator.extensions.safeCast
 import com.google.common.base.CaseFormat
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLDirective
+import java.lang.reflect.Field
 import kotlin.reflect.KAnnotatedElement
 import com.expedia.graphql.annotations.GraphQLDirective as GraphQLDirectiveAnnotation
 
@@ -15,6 +16,11 @@ internal class DirectiveTypeBuilder(generator: SchemaGenerator) : TypeBuilder(ge
 
     internal fun directives(element: KAnnotatedElement): List<GraphQLDirective> =
         element.annotations
+            .mapNotNull { it.getDirectiveInfo() }
+            .map(this::getDirective)
+
+    internal fun fieldDirectives(field: Field): List<GraphQLDirective> =
+        field.annotations
             .mapNotNull { it.getDirectiveInfo() }
             .map(this::getDirective)
 

--- a/src/main/kotlin/com/expedia/graphql/generator/types/EnumTypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/EnumTypeBuilder.kt
@@ -34,6 +34,11 @@ internal class EnumTypeBuilder(generator: SchemaGenerator) : TypeBuilder(generat
         valueBuilder.value(enum.name)
 
         val valueField = kClass.java.getField(enum.name)
+
+        generator.fieldDirectives(valueField).forEach {
+            valueBuilder.withDirective(it)
+        }
+
         valueBuilder.description(valueField.getGraphQLDescription())
         valueBuilder.deprecationReason(valueField.getDeprecationReason())
 

--- a/src/test/kotlin/com/expedia/graphql/generator/types/DirectiveTypeBuilderTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/DirectiveTypeBuilderTest.kt
@@ -19,7 +19,12 @@ internal class DirectiveTypeBuilderTest {
     internal annotation class DirectiveWithString(val string: String)
 
     internal enum class Type {
-        ONE, TWO
+        @DirectiveWithString("my string")
+        @DirectiveWithClass(SimpleDirective::class)
+        ONE,
+
+        @GraphQLDescription("my description")
+        TWO
     }
 
     @GraphQLDirective
@@ -85,5 +90,25 @@ internal class DirectiveTypeBuilderTest {
         basicGenerator.directives(MyClass::simpleDirective)
         basicGenerator.directives(MyClass::simpleDirective)
         assertEquals(1, basicGenerator.state.directives.size)
+    }
+
+    @Test
+    fun `directives are valid on fields (enum values)`() {
+        val field = Type::class.java.getField("ONE")
+
+        val directives = basicGenerator.fieldDirectives(field)
+
+        assertEquals(2, directives.size)
+        assertEquals("directiveWithString", directives.first().name)
+        assertEquals("directiveWithClass", directives.last().name)
+    }
+
+    @Test
+    fun `directives are empty on an enum with no valid annotations`() {
+        val field = Type::class.java.getField("TWO")
+
+        val directives = basicGenerator.fieldDirectives(field)
+
+        assertEquals(0, directives.size)
     }
 }

--- a/src/test/kotlin/com/expedia/graphql/generator/types/EnumTypeBuilderTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/EnumTypeBuilderTest.kt
@@ -1,6 +1,7 @@
 package com.expedia.graphql.generator.types
 
 import com.expedia.graphql.annotations.GraphQLDescription
+import com.expedia.graphql.utils.CustomDirective
 import com.expedia.graphql.utils.SimpleDirective
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -23,6 +24,8 @@ internal class EnumTypeBuilderTest : TypeTestHelper() {
         @Deprecated("Deprecated enum value")
         TWO,
 
+        @SimpleDirective
+        @CustomDirective("foo bar")
         @Deprecated("THREE is out", replaceWith = ReplaceWith("TWO"))
         THREE
     }
@@ -76,5 +79,22 @@ internal class EnumTypeBuilderTest : TypeTestHelper() {
         val gqlEnum = assertNotNull(builder.enumType(MyTestEnum::class))
         assertEquals(1, gqlEnum.directives.size)
         assertEquals("simpleDirective", gqlEnum.directives.first().name)
+    }
+
+    @Test
+    fun `Enum values can have a single directive`() {
+        val gqlEnum = assertNotNull(builder.enumType(MyTestEnum::class))
+
+        val directives = gqlEnum.values.last().directives
+        assertEquals(2, directives.size)
+        assertEquals("simpleDirective", directives.first().name)
+        assertEquals("customName", directives.last().name)
+    }
+
+    @Test
+    fun `Enum values can have a multiple directives`() {
+        val gqlEnum = assertNotNull(builder.enumType(MyTestEnum::class))
+        assertEquals(1, gqlEnum.values.first().directives.size)
+        assertEquals("simpleDirective", gqlEnum.values.first().directives.first().name)
     }
 }

--- a/src/test/kotlin/com/expedia/graphql/generator/types/TypeTestHelper.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/TypeTestHelper.kt
@@ -12,6 +12,7 @@ import graphql.schema.GraphQLInterfaceType
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
+import java.lang.reflect.Field
 import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
@@ -81,6 +82,11 @@ internal open class TypeTestHelper {
         directiveTypeBuilder = spyk(DirectiveTypeBuilder(generator))
         every { generator.directives(any()) } answers {
             val directives = directiveTypeBuilder!!.directives(it.invocation.args[0] as KAnnotatedElement)
+            state.directives.addAll(directives)
+            directives
+        }
+        every { generator.fieldDirectives(any()) } answers {
+            val directives = directiveTypeBuilder!!.fieldDirectives(it.invocation.args[0] as Field)
             state.directives.addAll(directives)
             directives
         }

--- a/src/test/kotlin/com/expedia/graphql/utils/CustomDirective.kt
+++ b/src/test/kotlin/com/expedia/graphql/utils/CustomDirective.kt
@@ -1,0 +1,6 @@
+package com.expedia.graphql.utils
+
+import com.expedia.graphql.annotations.GraphQLDirective
+
+@GraphQLDirective(name = "customName", description = "custom description")
+annotation class CustomDirective(val customValue: String)


### PR DESCRIPTION
Fixes https://github.com/ExpediaDotCom/graphql-kotlin/issues/175

The new example code

```kotlin
@GraphQLDescription("enum holding all supported animal types")
@SimpleDirective
enum class AnimalType {
    CAT,
    @SimpleDirective
    DOG
}
```

makes this schema in the SDL

```graphql
#enum holding all supported animal types
enum AnimalType @simpleDirective {
  CAT
  DOG @simpleDirective
}
```