### PR TITLE
fix: do not cache GraphQLTypeReference

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/generator/TypeBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/TypeBuilder.kt
@@ -9,6 +9,7 @@ import com.expedia.graphql.generator.extensions.wrapInNonNull
 import com.expedia.graphql.generator.state.KGraphQLType
 import com.expedia.graphql.generator.state.TypesCacheKey
 import graphql.schema.GraphQLType
+import graphql.schema.GraphQLTypeReference
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 
@@ -37,9 +38,11 @@ internal open class TypeBuilder constructor(protected val generator: SchemaGener
 
         val kClass = type.getKClass()
         val graphQLType = getGraphQLType(kClass, inputType, type)
-        val kGraphQLType = KGraphQLType(kClass, graphQLType)
 
-        state.cache.put(cacheKey, kGraphQLType)
+        if (graphQLType !is GraphQLTypeReference) {
+            val kGraphQLType = KGraphQLType(kClass, graphQLType)
+            state.cache.put(cacheKey, kGraphQLType)
+        }
 
         return graphQLType
     }

--- a/src/test/kotlin/com/expedia/graphql/generator/types/TypeTestHelper.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/TypeTestHelper.kt
@@ -28,14 +28,15 @@ import kotlin.test.BeforeTest
 internal open class TypeTestHelper {
     var generator = mockk<SchemaGenerator>()
     var config = mockk<SchemaGeneratorConfig>()
-    var state = spyk(SchemaGeneratorState(listOf("com.expedia.graphql.generator.types")))
-    var subTypeMapper = spyk(SubTypeMapper(listOf("com.expedia.graphql.generator.types")))
-    var cache = spyk(TypesCache(listOf("com.expedia.graphql.generator.types")))
+    var state = spyk(SchemaGeneratorState(listOf("com.expedia.graphql")))
+    var subTypeMapper = spyk(SubTypeMapper(listOf("com.expedia.graphql")))
+    var cache = spyk(TypesCache(listOf("com.expedia.graphql")))
     var hooks: SchemaGeneratorHooks = NoopSchemaGeneratorHooks()
     var dataFetcherFactory: KotlinDataFetcherFactoryProvider = KotlinDataFetcherFactoryProvider(hooks)
 
     private var scalarBuilder: ScalarBuilder? = null
     private var objectBuilder: ObjectBuilder? = null
+    private var listBuilder: ListBuilder? = null
     private var interfaceBuilder: InterfaceBuilder? = null
     private var directiveBuilder: DirectiveBuilder? = null
     private var functionBuilder: FunctionBuilder? = null
@@ -72,6 +73,11 @@ internal open class TypeTestHelper {
         objectBuilder = spyk(ObjectBuilder(generator))
         every { generator.objectType(any(), any()) } answers {
             objectBuilder!!.objectType(it.invocation.args[0] as KClass<*>, it.invocation.args[1] as GraphQLInterfaceType?)
+        }
+
+        listBuilder = spyk(ListBuilder(generator))
+        every { generator.listType(any(), any()) } answers {
+            listBuilder!!.listType(it.invocation.args[0] as KType, it.invocation.args[1] as Boolean)
         }
 
         interfaceBuilder = spyk(InterfaceBuilder(generator))

--- a/src/test/kotlin/com/expedia/graphql/test/integration/NodeGraphTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/test/integration/NodeGraphTest.kt
@@ -3,27 +3,28 @@ package com.expedia.graphql.test.integration
 import com.expedia.graphql.TopLevelObject
 import com.expedia.graphql.testSchemaConfig
 import com.expedia.graphql.toSchema
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLTypeReference
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class NodeGraphTest {
 
     @Test
     fun nodeGraph() {
-        val root = Node(id = 0, value = "root", parent = null, children = emptyList())
-        val nodeA = Node(id = 1, value = "A", parent = root, children = emptyList())
-        val nodeB = Node(id = 2, value = "B", parent = root, children = emptyList())
-        val nodeC = Node(id = 3, value = "C", parent = nodeB, children = emptyList())
-
-        root.children = listOf(nodeA, nodeB)
-        nodeB.children = listOf(nodeC)
-
         val queries = listOf(TopLevelObject(NodeQuery()))
 
         val schema = toSchema(queries = queries, config = testSchemaConfig)
 
         assertEquals(expected = 1, actual = schema.queryType.fieldDefinitions.size)
         assertEquals(expected = "nodeGraph", actual = schema.queryType.fieldDefinitions.first().name)
+
+        val nodeFields = (schema.typeMap["Node"] as? GraphQLObjectType)?.fieldDefinitions
+
+        nodeFields?.forEach {
+            assertFalse(it.type is GraphQLTypeReference, "Node.${it.name} is a GraphQLTypeReference")
+        }
     }
 }
 
@@ -34,16 +35,16 @@ class NodeGraphTest {
 data class Node(
     val id: Int,
     val value: String,
-    val parent: Node?,
-    var children: List<Node>
+    val parent: Node? = null,
+    var children: List<Node> = emptyList()
 )
 
 class NodeQuery {
 
-    private val root = Node(id = 0, value = "root", parent = null, children = emptyList())
-    private val nodeA = Node(id = 1, value = "A", parent = root, children = emptyList())
-    private val nodeB = Node(id = 2, value = "B", parent = root, children = emptyList())
-    private val nodeC = Node(id = 3, value = "C", parent = nodeB, children = emptyList())
+    private val root = Node(id = 0, value = "root")
+    private val nodeA = Node(id = 1, value = "A", parent = root)
+    private val nodeB = Node(id = 2, value = "B", parent = root)
+    private val nodeC = Node(id = 3, value = "C", parent = nodeB)
 
     init {
         root.children = listOf(nodeA, nodeB)


### PR DESCRIPTION
Fixes https://github.com/ExpediaDotCom/graphql-kotlin/issues/191

We are not going to resolve a type to a cached `GraphQLTypeReference`, instead we will try creating the full object or just create another `GraphQLTypeReference` if it still under construction.