### PR TITLE
feat: do not cache list types

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/kClassExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/kClassExtensions.kt
@@ -60,6 +60,6 @@ internal fun KClass<*>.getSimpleName(isInputClass: Boolean = false): String {
     }
 }
 
-internal fun KClass<*>.getQualifiedName(): String = this.qualifiedName ?: ""
+internal fun KClass<*>.getQualifiedName(): String = this.qualifiedName.orEmpty()
 
 internal fun KClass<*>.isPublic(): Boolean = this.visibility == KVisibility.PUBLIC

--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/kTypeExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/kTypeExtensions.kt
@@ -29,15 +29,7 @@ internal fun KType.getWrappedType(): KType {
     }
 }
 
-internal fun KType.getWrappedName(isInputType: Boolean = false): String {
-    val isPrimitiveArray = primitiveArrayTypes.containsKey(this.getKClass())
-    return when {
-        isPrimitiveArray -> this.getSimpleName()
-        this.getKClass().isList() -> "List<${this.getWrappedType().getSimpleName(isInputType)}>"
-        this.getKClass().isArray() -> "Array<${this.getWrappedType().getSimpleName(isInputType)}>"
-        else -> this.getSimpleName(isInputType)
-    }
-}
+internal fun KType.isPrimitiveArray() = primitiveArrayTypes.containsKey(this.getKClass())
 
 internal fun KType.getSimpleName(isInputType: Boolean = false): String = this.getKClass().getSimpleName(isInputType)
 

--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/kTypeExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/kTypeExtensions.kt
@@ -29,8 +29,6 @@ internal fun KType.getWrappedType(): KType {
     }
 }
 
-internal fun KType.isPrimitiveArray() = primitiveArrayTypes.containsKey(this.getKClass())
-
 internal fun KType.getSimpleName(isInputType: Boolean = false): String = this.getKClass().getSimpleName(isInputType)
 
 internal val KType.qualifiedName: String

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/KTypeExtensionsKtTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/KTypeExtensionsKtTest.kt
@@ -86,25 +86,4 @@ internal class KTypeExtensionsKtTest {
         assertEquals("com.expedia.graphql.generator.extensions.KTypeExtensionsKtTest.MyClass", MyClass::class.starProjectedType.qualifiedName)
         assertEquals("", object { }::class.starProjectedType.qualifiedName)
     }
-
-    @Test
-    fun getName() {
-        assertEquals("MyClass", MyClass::class.starProjectedType.getWrappedName())
-
-        assertEquals("MyClassInput", MyClass::class.starProjectedType.getWrappedName(isInputType = true))
-
-        assertEquals("List<String>", MyClass::listFun.findParameterByName("list")?.type?.getWrappedName())
-
-        assertEquals("List<StringInput>", MyClass::listFun.findParameterByName("list")?.type?.getWrappedName(isInputType = true))
-
-        assertEquals("Array<String>", MyClass::arrayFun.findParameterByName("array")?.type?.getWrappedName())
-
-        assertEquals("IntArray", MyClass::primitiveArrayFun.findParameterByName("intArray")?.type?.getWrappedName())
-
-        assertEquals("IntArray", MyClass::primitiveArrayFun.findParameterByName("intArray")?.type?.getWrappedName(isInputType = true))
-
-        assertFailsWith(CouldNotGetNameOfKClassException::class) {
-            object {}::class.starProjectedType.getWrappedName()
-        }
-    }
 }

--- a/src/test/kotlin/com/expedia/graphql/generator/state/TypesCacheTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/state/TypesCacheTest.kt
@@ -5,6 +5,7 @@ import graphql.schema.GraphQLTypeVisitor
 import graphql.util.TraversalControl
 import graphql.util.TraverserContext
 import org.junit.jupiter.api.Test
+import kotlin.reflect.full.findParameterByName
 import kotlin.reflect.full.starProjectedType
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -26,6 +27,16 @@ class TypesCacheTest {
         override fun getName(): String = "MySecondType"
 
         override fun accept(context: TraverserContext<GraphQLType>, visitor: GraphQLTypeVisitor): TraversalControl = context.thisNode().accept(context, visitor)
+    }
+
+    internal class MyClass {
+        fun listFun(list: List<String>) = list.joinToString(separator = ",") { it }
+
+        fun objectListFun(list: List<MyType>) = list.map { it.id.toString() }.joinToString(separator = ",") { it }
+
+        fun arrayFun(array: Array<String>) = array.joinToString(separator = ",") { it }
+
+        fun primitiveArrayFun(intArray: IntArray) = intArray.joinToString(separator = ",") { it.toString() }
     }
 
     @Test
@@ -54,6 +65,66 @@ class TypesCacheTest {
         cache.put(cacheKey, cacheValue)
 
         assertNotNull(cache.get(cacheKey))
+    }
+
+    @Test
+    fun `list types are not cached`() {
+        val cache = TypesCache(listOf("com.expedia.graphql"))
+
+        val type = MyClass::listFun.findParameterByName("list")?.type
+
+        assertNotNull(type)
+
+        val cacheKey = TypesCacheKey(type, false)
+        val cacheValue = KGraphQLType(MyType::class, graphQLType)
+
+        assertNull(cache.get(cacheKey))
+        assertNull(cache.put(cacheKey, cacheValue))
+    }
+
+    @Test
+    fun `list of objects are not cached`() {
+        val cache = TypesCache(listOf("com.expedia.graphql"))
+
+        val type = MyClass::objectListFun.findParameterByName("list")?.type
+
+        assertNotNull(type)
+
+        val cacheKey = TypesCacheKey(type, false)
+        val cacheValue = KGraphQLType(MyType::class, graphQLType)
+
+        assertNull(cache.get(cacheKey))
+        assertNull(cache.put(cacheKey, cacheValue))
+    }
+
+    @Test
+    fun `primitive array types are not cached`() {
+        val cache = TypesCache(listOf("com.expedia.graphql"))
+
+        val type = MyClass::primitiveArrayFun.findParameterByName("intArray")?.type
+
+        assertNotNull(type)
+
+        val cacheKey = TypesCacheKey(type, false)
+        val cacheValue = KGraphQLType(MyType::class, graphQLType)
+
+        assertNull(cache.get(cacheKey))
+        assertNull(cache.put(cacheKey, cacheValue))
+    }
+
+    @Test
+    fun `array types are not cached`() {
+        val cache = TypesCache(listOf("com.expedia.graphql"))
+
+        val type = MyClass::arrayFun.findParameterByName("array")?.type
+
+        assertNotNull(type)
+
+        val cacheKey = TypesCacheKey(type, false)
+        val cacheValue = KGraphQLType(MyType::class, graphQLType)
+
+        assertNull(cache.get(cacheKey))
+        assertNull(cache.put(cacheKey, cacheValue))
     }
 
     @Test


### PR DESCRIPTION
To simplify logic and make the cache simpler, we will not cache any list type. This means that the TypeCache is truly just caching fully qualified types. Lists will still be generated but they will not hit the cache to get their graphql type until they request a class.

This will also help if we want to support adding Sets to the types as it just becomes one location we have to update for all the valid list types