### PR TITLE
FunctionBuilder ignores parameters annotated with GraphQLIgnore

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/generator/types/FunctionBuilder.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/types/FunctionBuilder.kt
@@ -9,6 +9,7 @@ import com.expedia.graphql.generator.extensions.getName
 import com.expedia.graphql.generator.extensions.getTypeOfFirstArgument
 import com.expedia.graphql.generator.extensions.isDataFetchingEnvironment
 import com.expedia.graphql.generator.extensions.isGraphQLContext
+import com.expedia.graphql.generator.extensions.isGraphQLIgnored
 import com.expedia.graphql.generator.extensions.isInterface
 import com.expedia.graphql.generator.extensions.safeCast
 import graphql.schema.GraphQLArgument
@@ -37,6 +38,7 @@ internal class FunctionBuilder(generator: SchemaGenerator) : TypeBuilder(generat
 
         fn.valueParameters
             .filterNot { it.isGraphQLContext() }
+            .filterNot { it.isGraphQLIgnored() }
             .filterNot { it.isDataFetchingEnvironment() }
             .forEach {
                 // deprecation of arguments is currently unsupported: https://github.com/facebook/graphql/issues/197

--- a/src/test/kotlin/com/expedia/graphql/generator/types/FunctionBuilderTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/FunctionBuilderTest.kt
@@ -3,6 +3,7 @@ package com.expedia.graphql.generator.types
 import com.expedia.graphql.annotations.GraphQLContext
 import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.annotations.GraphQLDirective
+import com.expedia.graphql.annotations.GraphQLIgnore
 import com.expedia.graphql.execution.FunctionDataFetcher
 import graphql.Scalars
 import graphql.introspection.Introspection
@@ -51,6 +52,8 @@ internal class FunctionBuilderTest : TypeTestHelper() {
         fun saw(tree: String) = tree
 
         fun context(@GraphQLContext context: String, string: String) = "$context and $string"
+
+        fun ignoredParameter(color: String, @GraphQLIgnore ignoreMe: String) = "$color and $ignoreMe"
 
         fun completableFuture(num: Int): CompletableFuture<Int> = CompletableFuture.completedFuture(num)
 
@@ -126,6 +129,17 @@ internal class FunctionBuilderTest : TypeTestHelper() {
         assertEquals(expected = 1, actual = result.arguments.size)
         val arg = result.arguments.firstOrNull()
         assertEquals(expected = "string", actual = arg?.name)
+    }
+
+    @Test
+    fun `Test ignored parameter`() {
+        val kFunction = Happy::ignoredParameter
+        val result = builder.function(kFunction)
+
+        assertTrue(result.directives.isEmpty())
+        assertEquals(expected = 1, actual = result.arguments.size)
+        val arg = result.arguments.firstOrNull()
+        assertEquals(expected = "color", actual = arg?.name)
     }
 
     @Test


### PR DESCRIPTION
Currently `FunctionBuilder` includes all parameters except those annotated with `GraphQLContext` and those of type `DataFetchingEnvironment`: https://github.com/ExpediaDotCom/graphql-kotlin/blob/9915070a96b68d36528ee7cf28ba825e1e53dd85/src/main/kotlin/com/expedia/graphql/generator/types/FunctionBuilder.kt#L38-L41

With this present change, `FunctionBuilder` would also ignore parameters annotated with `@GraphQLIgnore`.

What follows is my concrete use case in the context of a Spring app, but the change would be convenient in other situations as well.

===

The example in the repo resolves nested queries by virtue of a `lateinit var` field (see https://github.com/ExpediaDotCom/graphql-kotlin/blob/3132d8851d67f2147f08590207279841a74338ad/example/src/main/kotlin/com/expedia/graphql/sample/query/NestedQueries.kt), with the associated data fetcher component getting resolved from the `BeanFactory` via a custom `SpringDataFetcherFactory`. This is quite cumbersome when nested queries require parameters, as seen here: https://github.com/ExpediaDotCom/graphql-kotlin/blob/3132d8851d67f2147f08590207279841a74338ad/example/src/main/kotlin/com/expedia/graphql/sample/query/NestedQueries.kt#L44-L49

A more convenient way would be to provide the nested query as a function in the data class, with bean component parameters annotated with Spring's `@Autowired`. A custom `AutowiringFunctionDataFetcher` resolves these annotated parameters to appropriate beans retrieved from the `BeanFactory`. The resulting data class looks as follows (contrived to match the repo's example):

```kotlin
data class NestedAnimal(
        val id: Int,
        val type: String
) {
    fun details(filter: String, @Autowired @GraphQLIgnore detailsRepository: DetailsRepository): Details {
        // retrieve details via detailsRepository
    }
}
```

Consequently the logic of the nested query lives in the data class itself instead of a separate `DataFetcher` class. Note that in my project I don't actually call data repositories directly in the data classes. Instead, the business logic is encapsulated in UseCase classes and the query is merely a call to a specific UseCase or Service (usually a one-liner). In this case having the logic in the data class isn't an issue.

Unfortunately the above approach doesn't currently work due to `FunctionBuilder` including all parameters, including the `@Autowired @GraphQLIgnore` parameters. Hence my proposed change.