### PR TITLE
Support custom names via @GraphQLName

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/annotations/GraphQLName.kt
+++ b/src/main/kotlin/com/expedia/graphql/annotations/GraphQLName.kt
@@ -1,0 +1,7 @@
+package com.expedia.graphql.annotations
+
+/**
+ * Set the GraphQL name to be picked up by the schema generator.
+ */
+@Target(AnnotationTarget.CLASS)
+annotation class GraphQLName(val value: String)

--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/annotationExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/annotationExtensions.kt
@@ -3,10 +3,13 @@ package com.expedia.graphql.generator.extensions
 import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.annotations.GraphQLID
 import com.expedia.graphql.annotations.GraphQLIgnore
+import com.expedia.graphql.annotations.GraphQLName
 import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.full.findAnnotation
 
 internal fun KAnnotatedElement.getGraphQLDescription(): String? = this.findAnnotation<GraphQLDescription>()?.value
+
+internal fun KAnnotatedElement.getGraphQLName(): String? = this.findAnnotation<GraphQLName>()?.value
 
 internal fun KAnnotatedElement.getDeprecationReason(): String? = this.findAnnotation<Deprecated>()?.getReason()
 

--- a/src/main/kotlin/com/expedia/graphql/generator/extensions/kClassExtensions.kt
+++ b/src/main/kotlin/com/expedia/graphql/generator/extensions/kClassExtensions.kt
@@ -54,7 +54,9 @@ internal fun KClass<*>.isListType(): Boolean = this.isList() || this.isArray()
 
 @Throws(CouldNotGetNameOfKClassException::class)
 internal fun KClass<*>.getSimpleName(isInputClass: Boolean = false): String {
-    val name = this.simpleName ?: throw CouldNotGetNameOfKClassException(this)
+    val name = this.getGraphQLName()
+        ?: this.simpleName
+        ?: throw CouldNotGetNameOfKClassException(this)
 
     return when {
         isInputClass -> if (name.endsWith(INPUT_SUFFIX)) name else "$name$INPUT_SUFFIX"

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/AnnotationExtensionsTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/AnnotationExtensionsTest.kt
@@ -3,6 +3,7 @@ package com.expedia.graphql.generator.extensions
 import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.annotations.GraphQLID
 import com.expedia.graphql.annotations.GraphQLIgnore
+import com.expedia.graphql.annotations.GraphQLName
 import org.junit.jupiter.api.Test
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.test.assertEquals
@@ -13,6 +14,7 @@ import kotlin.test.assertTrue
 @Suppress("Detekt.UnusedPrivateClass")
 internal class AnnotationExtensionsTest {
 
+    @GraphQLName("WithAnnotationsCustomName")
     @GraphQLDescription("class description")
     @Deprecated("class deprecated")
     @GraphQLIgnore
@@ -24,6 +26,12 @@ internal class AnnotationExtensionsTest {
     )
 
     private data class NoAnnotations(val id: String)
+
+    @Test
+    fun `verify @GraphQLName on classes`() {
+        assertEquals(expected = "WithAnnotationsCustomName", actual = WithAnnotations::class.getGraphQLName())
+        assertNull(NoAnnotations::class.getGraphQLName())
+    }
 
     @Test
     fun `verify @GraphQLDescrption on classes`() {

--- a/src/test/kotlin/com/expedia/graphql/generator/extensions/KClassExtensionsTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/extensions/KClassExtensionsTest.kt
@@ -1,5 +1,6 @@
 package com.expedia.graphql.generator.extensions
 
+import com.expedia.graphql.annotations.GraphQLName
 import com.expedia.graphql.exceptions.CouldNotGetNameOfKClassException
 import com.expedia.graphql.hooks.NoopSchemaGeneratorHooks
 import com.expedia.graphql.hooks.SchemaGeneratorHooks
@@ -48,9 +49,15 @@ open class KClassExtensionsTest {
         private fun privateTestFunction() = "private function"
     }
 
+    @GraphQLName("MyTestClassRenamed")
+    private class MyTestClassCustomName
+
     internal class MyInternalClass
 
     class MyClassInput
+
+    @GraphQLName("MyClassRenamedInput")
+    class MyClassCustomNameInput
 
     protected class MyProtectedClass
 
@@ -210,9 +217,20 @@ open class KClassExtensionsTest {
     }
 
     @Test
+    fun `test class simple name with GraphQLName`() {
+        assertEquals("MyTestClassRenamed", MyTestClassCustomName::class.getSimpleName())
+    }
+
+    @Test
     fun `test input class name`() {
         assertEquals("MyTestClassInput", MyTestClass::class.getSimpleName(true))
         assertEquals("MyClassInput", MyClassInput::class.getSimpleName(true))
+    }
+
+    @Test
+    fun `test input class name with GraphQLName`() {
+        assertEquals("MyTestClassRenamedInput", MyTestClassCustomName::class.getSimpleName(true))
+        assertEquals("MyClassRenamedInput", MyClassCustomNameInput::class.getSimpleName(true))
     }
 
     @Test

--- a/src/test/kotlin/com/expedia/graphql/generator/types/EnumBuilderTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/EnumBuilderTest.kt
@@ -1,6 +1,7 @@
 package com.expedia.graphql.generator.types
 
 import com.expedia.graphql.annotations.GraphQLDescription
+import com.expedia.graphql.annotations.GraphQLName
 import com.expedia.graphql.test.utils.CustomDirective
 import com.expedia.graphql.test.utils.SimpleDirective
 import org.junit.jupiter.api.Test
@@ -30,6 +31,10 @@ internal class EnumBuilderTest : TypeTestHelper() {
         THREE
     }
 
+    @Suppress("Detekt.UnusedPrivateClass")
+    @GraphQLName("MyTestEnumRenamed")
+    private enum class MyTestEnumCustomName
+
     lateinit var builder: EnumBuilder
 
     override fun beforeTest() {
@@ -45,6 +50,12 @@ internal class EnumBuilderTest : TypeTestHelper() {
         assertEquals(expected = "ONE", actual = actual.values[0].value)
         assertEquals(expected = "TWO", actual = actual.values[1].value)
         assertEquals(expected = "THREE", actual = actual.values[2].value)
+    }
+
+    @Test
+    fun `Custom name on enum class`() {
+        val gqlEnum = assertNotNull(builder.enumType(MyTestEnumCustomName::class))
+        assertEquals("MyTestEnumRenamed", gqlEnum.name)
     }
 
     @Test

--- a/src/test/kotlin/com/expedia/graphql/generator/types/InputObjectBuilderTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/InputObjectBuilderTest.kt
@@ -1,6 +1,7 @@
 package com.expedia.graphql.generator.types
 
 import com.expedia.graphql.annotations.GraphQLDescription
+import com.expedia.graphql.annotations.GraphQLName
 import com.expedia.graphql.test.utils.SimpleDirective
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -17,8 +18,13 @@ internal class InputObjectBuilderTest : TypeTestHelper() {
     @GraphQLDescription("The truth")
     @SimpleDirective
     private class InputClass {
-
         @SimpleDirective
+        val myField: String = "car"
+    }
+
+    @Suppress("Detekt.UnusedPrivateClass")
+    @GraphQLName("InputClassRenamed")
+    private class InputClassCustomName {
         val myField: String = "car"
     }
 
@@ -26,6 +32,12 @@ internal class InputObjectBuilderTest : TypeTestHelper() {
     fun `Test naming`() {
         val result = builder.inputObjectType(InputClass::class)
         assertEquals("InputClassInput", result.name)
+    }
+
+    @Test
+    fun `Test custom naming`() {
+        val result = builder.inputObjectType(InputClassCustomName::class)
+        assertEquals("InputClassRenamedInput", result.name)
     }
 
     @Test

--- a/src/test/kotlin/com/expedia/graphql/generator/types/InterfaceBuilderTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/InterfaceBuilderTest.kt
@@ -1,6 +1,7 @@
 package com.expedia.graphql.generator.types
 
 import com.expedia.graphql.annotations.GraphQLDescription
+import com.expedia.graphql.annotations.GraphQLName
 import com.expedia.graphql.test.utils.SimpleDirective
 import graphql.schema.GraphQLInterfaceType
 import org.junit.jupiter.api.Test
@@ -19,10 +20,20 @@ internal class InterfaceBuilderTest : TypeTestHelper() {
     @SimpleDirective
     private interface HappyInterface
 
+    @Suppress("Detekt.UnusedPrivateClass")
+    @GraphQLName("HappyInterfaceRenamed")
+    private interface HappyInterfaceCustomName
+
     @Test
     fun `Test naming`() {
         val result = builder.interfaceType(HappyInterface::class) as? GraphQLInterfaceType
         assertEquals("HappyInterface", result?.name)
+    }
+
+    @Test
+    fun `Test custom naming`() {
+        val result = builder.interfaceType(HappyInterfaceCustomName::class) as? GraphQLInterfaceType
+        assertEquals("HappyInterfaceRenamed", result?.name)
     }
 
     @Test

--- a/src/test/kotlin/com/expedia/graphql/generator/types/ObjectBuilderTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/ObjectBuilderTest.kt
@@ -2,6 +2,7 @@ package com.expedia.graphql.generator.types
 
 import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.annotations.GraphQLDirective
+import com.expedia.graphql.annotations.GraphQLName
 import graphql.Scalars
 import graphql.introspection.Introspection
 import graphql.schema.GraphQLNonNull
@@ -26,11 +27,21 @@ internal class ObjectBuilderTest : TypeTestHelper() {
     @ObjectDirective("Don't worry")
     private class BeHappy
 
+    @GraphQLName("BeHappyRenamed")
+    private class BeHappyCustomName
+
     @Test
     fun `Test naming`() {
         val result = builder.objectType(BeHappy::class) as? GraphQLObjectType
         assertNotNull(result)
         assertEquals("BeHappy", result.name)
+    }
+
+    @Test
+    fun `Test custom naming`() {
+        val result = builder.objectType(BeHappyCustomName::class) as? GraphQLObjectType
+        assertNotNull(result)
+        assertEquals("BeHappyRenamed", result.name)
     }
 
     @Test

--- a/src/test/kotlin/com/expedia/graphql/generator/types/UnionBuilderTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/generator/types/UnionBuilderTest.kt
@@ -1,6 +1,7 @@
 package com.expedia.graphql.generator.types
 
 import com.expedia.graphql.annotations.GraphQLDescription
+import com.expedia.graphql.annotations.GraphQLName
 import com.expedia.graphql.test.utils.SimpleDirective
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLUnionType
@@ -24,6 +25,12 @@ internal class UnionBuilderTest : TypeTestHelper() {
     @GraphQLDescription("so red")
     private class StrawBerryCake : Cake
 
+    @GraphQLName("CakeRenamed")
+    private interface CakeCustomName
+
+    @GraphQLName("StrawBerryCakeRenamed")
+    private class StrawBerryCakeCustomName : CakeCustomName
+
     @Test
     fun `Test naming`() {
         val result = builder.unionType(Cake::class) as? GraphQLUnionType
@@ -32,6 +39,16 @@ internal class UnionBuilderTest : TypeTestHelper() {
         assertEquals(Cake::class.java.simpleName, result.name)
         assertEquals(1, result.types.size)
         assertEquals(StrawBerryCake::class.java.simpleName, result.types[0].name)
+    }
+
+    @Test
+    fun `Test custom naming`() {
+        val result = builder.unionType(CakeCustomName::class) as? GraphQLUnionType
+        assertNotNull(result)
+
+        assertEquals("CakeRenamed", result.name)
+        assertEquals(1, result.types.size)
+        assertEquals("StrawBerryCakeRenamed", result.types[0].name)
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/ExpediaDotCom/graphql-kotlin/issues/210

I went ahead and packaged my local changes into a PR, even before hearing back whether it's desirable in upstream. It might be useful to somebody else, regardless of whether it gets merged. Thanks.