### PR TITLE
FunctionDataFetch throws `InvocationException.cause` property when available

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/execution/FunctionDataFetcher.kt
+++ b/src/main/kotlin/com/expedia/graphql/execution/FunctionDataFetcher.kt
@@ -11,10 +11,12 @@ import graphql.schema.DataFetchingEnvironment
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.future.asCompletableFuture
+import java.lang.reflect.InvocationTargetException
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.callSuspend
 import kotlin.reflect.full.valueParameters
+import java.util.concurrent.ExecutionException as ExecutionException1
 
 /**
  * Simple DataFetcher that invokes target function on the given object.
@@ -46,7 +48,11 @@ class FunctionDataFetcher(
                     fn.callSuspend(it, *parameterValues)
                 }.asCompletableFuture()
             } else {
-                fn.call(it, *parameterValues)
+                try {
+                    return fn.call(it, *parameterValues)
+                } catch (exception: InvocationTargetException) {
+                    throw exception.cause ?: exception
+                }
             }
         }
     }

--- a/src/main/kotlin/com/expedia/graphql/execution/FunctionDataFetcher.kt
+++ b/src/main/kotlin/com/expedia/graphql/execution/FunctionDataFetcher.kt
@@ -16,7 +16,6 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.callSuspend
 import kotlin.reflect.full.valueParameters
-import java.util.concurrent.ExecutionException as ExecutionException1
 
 /**
  * Simple DataFetcher that invokes target function on the given object.

--- a/src/test/kotlin/com/expedia/graphql/execution/FunctionDataFetcherTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/execution/FunctionDataFetcherTest.kt
@@ -37,7 +37,7 @@ internal class FunctionDataFetcherTest {
 
         fun throwException() { throw GraphQLException("Test Exception") }
 
-        suspend fun suspendThrow(): CompletableFuture<*> = coroutineScope {
+        suspend fun suspendThrow(): String = coroutineScope {
             delay(10)
             throw GraphQLException("Suspended Exception")
         }

--- a/src/test/kotlin/com/expedia/graphql/execution/FunctionDataFetcherTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/execution/FunctionDataFetcherTest.kt
@@ -13,7 +13,9 @@ import java.util.concurrent.CompletableFuture
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 internal class FunctionDataFetcherTest {
 

--- a/src/test/kotlin/com/expedia/graphql/execution/FunctionDataFetcherTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/execution/FunctionDataFetcherTest.kt
@@ -35,7 +35,7 @@ internal class FunctionDataFetcherTest {
             string
         }
 
-        fun throwException () { throw GraphQLException("Test Exception") }
+        fun throwException() { throw GraphQLException("Test Exception") }
 
         suspend fun suspendThrow(): CompletableFuture<*> = coroutineScope {
             delay(10)

--- a/src/test/kotlin/com/expedia/graphql/execution/FunctionDataFetcherTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/execution/FunctionDataFetcherTest.kt
@@ -2,6 +2,7 @@ package com.expedia.graphql.execution
 
 import com.expedia.graphql.annotations.GraphQLContext
 import com.expedia.graphql.exceptions.CouldNotCastArgumentException
+import graphql.GraphQLException
 import graphql.schema.DataFetchingEnvironment
 import io.mockk.every
 import io.mockk.mockk
@@ -30,6 +31,13 @@ internal class FunctionDataFetcherTest {
         suspend fun suspendPrint(string: String): String = coroutineScope {
             delay(10)
             string
+        }
+
+        fun throwException () { throw GraphQLException("Test Exception") }
+
+        suspend fun suspendThrow(): CompletableFuture<*> = coroutineScope {
+            delay(10)
+            throw GraphQLException("Suspended Exception")
         }
     }
 
@@ -125,5 +133,35 @@ internal class FunctionDataFetcherTest {
 
         assertTrue(result is CompletableFuture<*>)
         assertEquals(expected = "hello", actual = result.get())
+    }
+
+    @Test
+    fun `throwException function propagates the original exception`() {
+        val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::throwException)
+        val mockEnvironmet: DataFetchingEnvironment = mockk()
+
+        try {
+            dataFetcher.get(mockEnvironmet)
+            assertFalse(true, "Should not be here")
+        } catch (e: Exception) {
+            assertEquals(e.message, "Test Exception")
+        }
+    }
+
+    @Test
+    fun `suspendThrow throws exception when resolved`() {
+        val dataFetcher = FunctionDataFetcher(target = MyClass(), fn = MyClass::suspendThrow)
+        val mockEnvironmet: DataFetchingEnvironment = mockk()
+
+        try {
+            val result = dataFetcher.get(mockEnvironmet)
+            assertTrue(result is CompletableFuture<*>)
+            result.get()
+            assertFalse(true, "Should not be here")
+        } catch (e: Exception) {
+            val message = e.message
+            assertNotNull(message)
+            assertTrue(message.endsWith("Suspended Exception"))
+        }
     }
 }


### PR DESCRIPTION
This allows thrown `GraphQLException` instances to be handled by
`graph-java` as it would if thrown directly by a `DataFetcher` lambda.

---

I'm working on a prototype for an API gateway, a snippet of my login resolve is as follows

```kotlin
        val body = /* Usernam and password json object*/
        client.post(/* port */, /* domain */, /* path */)
            .putHeader("Accept", "application/json")
            .putHeader("Content-Type", "application/json")
            .sendJsonObject(body, {ar -> tokenFuture.complete(ar); })

        val response = tokenFuture.get()
        val result = response.result()

        if (result.statusCode() != 200) {
            throw GraphQLException("Username and password combination failed.")
        }
```

When Implementing directly with Graphql-Java's `DataFetchers` the error messages would appear as expected.

```json
{
  "data": null,
  "errors": [
    {
      "message": "Exception while fetching data (/login) : Username and password combination failed.",
      "locations": [
        {
          "line": 6,
          "column": 3
        }
      ],
      "path": [
        "login"
      ]
    }
  ]
}
```

However, when Implemented using this library  it would get null for the exception details.

```json
{
  "data": null,
  "errors": [
    {
      "message": "Exception while fetching data (/login) : null",
      "locations": [
        {
          "line": 6,
          "column": 3
        }
      ],
      "path": [
        "login"
      ]
    }
  ]
}
```

---

Update:

I've added tests, and remove changes to the async branch. The message is already included in the `ExecutionException` that is thrown by that branch. And I didn't want to add another layer of synchronization just to clean up the error messages.