### PR TITLE
feat: new hook for modifying object types

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/hooks/SchemaGeneratorHooks.kt
+++ b/src/main/kotlin/com/expedia/graphql/hooks/SchemaGeneratorHooks.kt
@@ -29,6 +29,12 @@ interface SchemaGeneratorHooks {
     fun willGenerateGraphQLType(type: KType): GraphQLType? = null
 
     /**
+     * Called after using reflection to generate the graphql object type but before returning it to the schema builder.
+     * This allows for modifying the type info, like description or directives
+     */
+    fun willAddGraphQLTypeToSchema(type: KType, generatedType: GraphQLType): GraphQLType = generatedType
+
+    /**
      * Called before resolving a KType to the GraphQL type.
      * This allows for a custom resolver on how to extract wrapped values, like in a CompletableFuture.
      */


### PR DESCRIPTION
Fixes https://github.com/ExpediaDotCom/graphql-kotlin/issues/231

Adds a new hook that can be used to modify all the GraphQLTypes that get generated from reflection. This allows for runtime documentation or any other changes that may want to be made to types after they are fully generated