### PR TITLE
fix: update TypeNotSupportedException message

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/exceptions/TypeNotSupportedException.kt
+++ b/src/main/kotlin/com/expedia/graphql/exceptions/TypeNotSupportedException.kt
@@ -6,4 +6,4 @@ import kotlin.reflect.KType
  * Thrown when the generator does not have a type to map to in GraphQL or in the hooks.
  */
 class TypeNotSupportedException(kType: KType, packageList: List<String>)
-    : GraphQLKotlinException("Cannot convert $kType since it is outside the supported packages $packageList")
+    : GraphQLKotlinException("Cannot convert $kType since it is not a valid GraphQL type or outside the supported packages $packageList")


### PR DESCRIPTION
Update the exception message to be clear about the situations in which the exception can be thrown. One of the most common questions we get is around trying to use ` Map<>` which is not a valid type for a GraphQL schema.