### PR TITLE
Revert throwing exception on missing directive wiring

### DIFF
--- a/src/main/kotlin/com/expedia/graphql/directives/KotlinDirectiveWiringFactory.kt
+++ b/src/main/kotlin/com/expedia/graphql/directives/KotlinDirectiveWiringFactory.kt
@@ -10,11 +10,6 @@ import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLType
 
 /**
- * Default no-op wiring for deprecated directive.
- */
-private val defaultDeprecatedWiring = object : KotlinSchemaDirectiveWiring {}
-
-/**
  * Wiring factory that is used to provide the directives.
  */
 open class KotlinDirectiveWiringFactory(
@@ -64,23 +59,15 @@ open class KotlinDirectiveWiringFactory(
             val directiveWiring = discoverWiringProvider(directive.name, env)
             if (directiveWiring != null) {
                 modifiedObject = directiveWiring.wireOnEnvironment(env)
-            } else {
-                throw InvalidSchemaDirectiveWiringException("No directive wiring provided for ${directive.name}")
             }
         }
         return modifiedObject
     }
 
-    private fun discoverWiringProvider(directiveName: String, env: KotlinSchemaDirectiveEnvironment<GraphQLDirectiveContainer>): KotlinSchemaDirectiveWiring? {
-        var wiring = if (directiveName in manualWiring) {
+    private fun discoverWiringProvider(directiveName: String, env: KotlinSchemaDirectiveEnvironment<GraphQLDirectiveContainer>): KotlinSchemaDirectiveWiring? =
+        if (directiveName in manualWiring) {
             manualWiring[directiveName]
         } else {
             getSchemaDirectiveWiring(env)
         }
-
-        if (null == wiring && DEPRECATED_DIRECTIVE_NAME == directiveName) {
-            wiring = defaultDeprecatedWiring
-        }
-        return wiring
-    }
 }

--- a/src/test/kotlin/com/expedia/graphql/directives/KotlinDirectiveWiringFactoryTest.kt
+++ b/src/test/kotlin/com/expedia/graphql/directives/KotlinDirectiveWiringFactoryTest.kt
@@ -92,12 +92,11 @@ class KotlinDirectiveWiringFactoryTest {
     }
 
     @Test
-    fun `verify exception is thrown if no wirings are specified`() {
+    fun `verify no action is taken if no wirings are specified`() {
         val original = GraphQLEnumType.newEnum().name("MyEnum").withDirective(graphQLOverrideDescriptionDirective).build()
 
-        assertThrows<InvalidSchemaDirectiveWiringException> {
-            SimpleWiringFactory().onWire(original)
-        }
+        val modified = SimpleWiringFactory().onWire(original)
+        assertEquals(original, modified)
     }
 
     @Test


### PR DESCRIPTION
There are use cases when directives could be just informational (e.g. @deprecated). Instead of defining no-op directive wiring we should just ignore directives without wiring.