### PR TITLE
Add back the example script step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
 
 script:
   - ./mvnw install
+  - ./mvnw -f example/pom.xml verify
 
 deploy:
   provider: script


### PR DESCRIPTION
I accidentally copied over the scripts steps from the master branch which changed the structure of the repo. In the `0.6.x` branch we still want to verify the example repo