### PR TITLE
Explicitly disable nexus-staging-maven-plugin in example app

### DIFF
--- a/graphql-kotlin-spring-example/pom.xml
+++ b/graphql-kotlin-spring-example/pom.xml
@@ -16,6 +16,9 @@
 
     <properties>
         <spring-boot.version>2.1.2.RELEASE</spring-boot.version>
+
+        <!-- skip release plugins -->
+        <maven.source.skip>true</maven.source.skip>
     </properties>
 
     <dependencies>
@@ -74,20 +77,25 @@
 <!--                <artifactId>maven-antrun-plugin</artifactId>-->
 <!--            </plugin>-->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <!-- don't publish this artifact -->
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.jetbrains.dokka</groupId>
                 <artifactId>dokka-maven-plugin</artifactId>
+                <version>${dokka-maven-plugin.version}</version>
                 <configuration>
                     <!-- don't generate javadocs as there is no artifact-->
                     <skip>true</skip>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.8</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>default-deploy</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,9 @@
         <detekt-cli.version>1.0.0-RC14</detekt-cli.version>
         <ktlint.version>0.30.0</ktlint.version>
         <jacoco-maven-plugin.version>0.8.3</jacoco-maven-plugin.version>
+
+        <!-- disable default maven-deploy-plugin in favor of nexus-staging-maven-plugin -->
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <pluginRepositories>
@@ -342,11 +345,6 @@
                 </property>
             </activation>
 
-            <!-- Exclude the example app from releases -->
-            <modules>
-                <module>graphql-kotlin-schema-generator</module>
-            </modules>
-
             <build>
                 <plugins>
                     <!-- Release to Maven central -->
@@ -384,20 +382,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <!-- Attach javadocs to jar -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.0.1</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <!-- Sign the artifacts -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -421,11 +405,6 @@
             <activation>
                 <jdk>1.8</jdk>
             </activation>
-
-            <!-- Exclude the example app from javadoc packages -->
-            <modules>
-                <module>graphql-kotlin-schema-generator</module>
-            </modules>
 
             <build>
                 <plugins>


### PR DESCRIPTION
Additional configuration fixes:
* remove maven-javadoc-plugin as dokka already genertes the javadoc jar
* explicitly disable maven-deploy-plugin as we are using nexus-staging-maven-plugin with explicit config
* skip generating sources for the example app