### PR TITLE
feat: allow renaming of properties and functions

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/annotations/GraphQLName.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/annotations/GraphQLName.kt
@@ -3,5 +3,5 @@ package com.expedia.graphql.annotations
 /**
  * Set the GraphQL name to be picked up by the schema generator.
  */
-@Target(AnnotationTarget.CLASS)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION)
 annotation class GraphQLName(val value: String)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/extensions/kCallableExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/extensions/kCallableExtensions.kt
@@ -4,3 +4,5 @@ import kotlin.reflect.KCallable
 import kotlin.reflect.KVisibility
 
 internal fun KCallable<*>.isPublic(): Boolean = this.visibility == KVisibility.PUBLIC
+
+internal fun KCallable<*>.getFunctionName(): String = this.getGraphQLName() ?: this.name

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/extensions/kPropertyExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/extensions/kPropertyExtensions.kt
@@ -21,4 +21,7 @@ internal fun KProperty<*>.getPropertyDeprecationReason(parentClass: KClass<*>): 
 internal fun KProperty<*>.getPropertyDescription(parentClass: KClass<*>): String? =
     this.getGraphQLDescription() ?: getConstructorParameter(parentClass)?.getGraphQLDescription()
 
+internal fun KProperty<*>.getPropertyName(parentClass: KClass<*>): String? =
+    this.getGraphQLName() ?: getConstructorParameter(parentClass)?.getGraphQLName() ?: this.name
+
 private fun KProperty<*>.getConstructorParameter(parentClass: KClass<*>) = parentClass.findConstructorParamter(this.name)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/types/FunctionBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/types/FunctionBuilder.kt
@@ -5,6 +5,7 @@ import com.expedia.graphql.exceptions.InvalidInputFieldTypeException
 import com.expedia.graphql.generator.SchemaGenerator
 import com.expedia.graphql.generator.TypeBuilder
 import com.expedia.graphql.generator.extensions.getDeprecationReason
+import com.expedia.graphql.generator.extensions.getFunctionName
 import com.expedia.graphql.generator.extensions.getGraphQLDescription
 import com.expedia.graphql.generator.extensions.getKClass
 import com.expedia.graphql.generator.extensions.getName
@@ -30,7 +31,8 @@ internal class FunctionBuilder(generator: SchemaGenerator) : TypeBuilder(generat
 
     internal fun function(fn: KFunction<*>, parentName: String, target: Any? = null, abstract: Boolean = false): GraphQLFieldDefinition {
         val builder = GraphQLFieldDefinition.newFieldDefinition()
-        builder.name(fn.name)
+        val functionName = fn.getFunctionName()
+        builder.name(functionName)
         builder.description(fn.getGraphQLDescription())
 
         fn.getDeprecationReason()?.let {
@@ -56,7 +58,7 @@ internal class FunctionBuilder(generator: SchemaGenerator) : TypeBuilder(generat
         builder.type(graphQLTypeOf(returnType).safeCast<GraphQLOutputType>())
         val graphQLType = builder.build()
 
-        val coordinates = FieldCoordinates.coordinates(parentName, fn.name)
+        val coordinates = FieldCoordinates.coordinates(parentName, functionName)
         if (!abstract) {
             val dataFetcherFactory = config.dataFetcherFactoryProvider.functionDataFetcherFactory(target = target, kFunction = fn)
             generator.codeRegistry.dataFetcher(coordinates, dataFetcherFactory)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/types/InputObjectBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/types/InputObjectBuilder.kt
@@ -4,6 +4,7 @@ import com.expedia.graphql.generator.SchemaGenerator
 import com.expedia.graphql.generator.TypeBuilder
 import com.expedia.graphql.generator.extensions.getGraphQLDescription
 import com.expedia.graphql.generator.extensions.getPropertyDescription
+import com.expedia.graphql.generator.extensions.getPropertyName
 import com.expedia.graphql.generator.extensions.getSimpleName
 import com.expedia.graphql.generator.extensions.getValidProperties
 import com.expedia.graphql.generator.extensions.isPropertyGraphQLID
@@ -36,7 +37,7 @@ internal class InputObjectBuilder(generator: SchemaGenerator) : TypeBuilder(gene
         val builder = GraphQLInputObjectField.newInputObjectField()
 
         builder.description(prop.getPropertyDescription(parentClass))
-        builder.name(prop.name)
+        builder.name(prop.getPropertyName(parentClass))
         builder.type(graphQLTypeOf(prop.returnType, true, prop.isPropertyGraphQLID(parentClass)).safeCast<GraphQLInputType>())
 
         generator.directives(prop).forEach {

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/types/PropertyBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/types/PropertyBuilder.kt
@@ -5,6 +5,7 @@ import com.expedia.graphql.generator.SchemaGenerator
 import com.expedia.graphql.generator.TypeBuilder
 import com.expedia.graphql.generator.extensions.getPropertyDeprecationReason
 import com.expedia.graphql.generator.extensions.getPropertyDescription
+import com.expedia.graphql.generator.extensions.getPropertyName
 import com.expedia.graphql.generator.extensions.getSimpleName
 import com.expedia.graphql.generator.extensions.isPropertyGraphQLID
 import com.expedia.graphql.generator.extensions.safeCast
@@ -21,7 +22,7 @@ internal class PropertyBuilder(generator: SchemaGenerator) : TypeBuilder(generat
 
         val fieldBuilder = GraphQLFieldDefinition.newFieldDefinition()
             .description(prop.getPropertyDescription(parentClass))
-            .name(prop.name)
+            .name(prop.getPropertyName(parentClass))
             .type(propertyType)
 
         prop.getPropertyDeprecationReason(parentClass)?.let {

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expedia/graphql/extensions/GraphQLSchemaExtensionsTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expedia/graphql/extensions/GraphQLSchemaExtensionsTest.kt
@@ -43,11 +43,13 @@ class GraphQLSchemaExtensionsTest {
     }
 
     class RenamedQuery {
+        @GraphQLName("renamedFunction")
         fun original(id: Int) = OriginalType(id)
     }
 
     @GraphQLName("RenamedType")
     class OriginalType(
+        @GraphQLName("renamedProperty")
         val originalProperty: Int
     )
 
@@ -58,11 +60,11 @@ class GraphQLSchemaExtensionsTest {
         val sdl = schema.print(includeDefaultSchemaDefinition = false, includeDirectives = false).trim()
         val expected = """
             type Query {
-              original(id: Int!): RenamedType!
+              renamedFunction(id: Int!): RenamedType!
             }
 
             type RenamedType {
-              originalProperty: Int!
+              renamedProperty: Int!
             }
         """.trimIndent()
         assertEquals(expected, sdl)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expedia/graphql/generator/extensions/KCallableExtensionsKtTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expedia/graphql/generator/extensions/KCallableExtensionsKtTest.kt
@@ -1,7 +1,9 @@
 package com.expedia.graphql.generator.extensions
 
+import com.expedia.graphql.annotations.GraphQLName
 import org.junit.jupiter.api.Test
 import kotlin.reflect.full.functions
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -16,6 +18,9 @@ internal class KCallableExtensionsKtTest {
         internal fun internal() = 3
 
         private fun private() = 4
+
+        @GraphQLName("renamedFunction")
+        fun originalName() = 1
     }
 
     @Test
@@ -24,5 +29,11 @@ internal class KCallableExtensionsKtTest {
         assertFalse(MyTestClass::internal.isPublic())
         assertFalse(MyTestClass::class.functions.find { it.name == "protected" }?.isPublic().isTrue())
         assertFalse(MyTestClass::class.functions.find { it.name == "private" }?.isPublic().isTrue())
+    }
+
+    @Test
+    fun graphQLName() {
+        assertEquals(expected = "renamedFunction", actual = MyTestClass::originalName.getFunctionName())
+        assertEquals(expected = "public", actual = MyTestClass::public.getFunctionName())
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expedia/graphql/generator/extensions/KPropertyExtensionsKtTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expedia/graphql/generator/extensions/KPropertyExtensionsKtTest.kt
@@ -3,6 +3,7 @@ package com.expedia.graphql.generator.extensions
 import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.annotations.GraphQLID
 import com.expedia.graphql.annotations.GraphQLIgnore
+import com.expedia.graphql.annotations.GraphQLName
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -18,12 +19,14 @@ internal class KPropertyExtensionsKtTest {
         @property:GraphQLDescription("property description")
         @property:GraphQLID
         @property:GraphQLIgnore
+        @property:GraphQLName("nameOnProperty")
         val propertyAnnotation: String,
 
         @Deprecated("constructor deprecated")
         @GraphQLDescription("constructor description")
         @GraphQLID
         @GraphQLIgnore
+        @GraphQLName("nameOnConstructor")
         val constructorAnnotation: String,
 
         val noAnnotations: String
@@ -55,5 +58,12 @@ internal class KPropertyExtensionsKtTest {
         assertEquals("property description", MyDataClass::propertyAnnotation.getPropertyDescription(MyDataClass::class))
         assertEquals("constructor description", MyDataClass::constructorAnnotation.getPropertyDescription(MyDataClass::class))
         assertEquals(null, MyDataClass::noAnnotations.getPropertyDescription(MyDataClass::class))
+    }
+
+    @Test
+    fun getPropertyName() {
+        assertEquals("nameOnProperty", MyDataClass::propertyAnnotation.getPropertyName(MyDataClass::class))
+        assertEquals("nameOnConstructor", MyDataClass::constructorAnnotation.getPropertyName(MyDataClass::class))
+        assertEquals("noAnnotations", MyDataClass::noAnnotations.getPropertyName(MyDataClass::class))
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expedia/graphql/generator/types/FunctionBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expedia/graphql/generator/types/FunctionBuilderTest.kt
@@ -4,6 +4,7 @@ import com.expedia.graphql.annotations.GraphQLContext
 import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.annotations.GraphQLDirective
 import com.expedia.graphql.annotations.GraphQLIgnore
+import com.expedia.graphql.annotations.GraphQLName
 import com.expedia.graphql.execution.FunctionDataFetcher
 import graphql.Scalars
 import graphql.introspection.Introspection
@@ -52,6 +53,9 @@ internal class FunctionBuilderTest : TypeTestHelper() {
         @Deprecated("Should paint instead")
         fun sketch(tree: String) = tree
 
+        @GraphQLName("renamedFunction")
+        fun originalName(input: String) = input
+
         @Deprecated("No saw, just paint", replaceWith = ReplaceWith("paint"))
         fun saw(tree: String) = tree
 
@@ -92,6 +96,13 @@ internal class FunctionBuilderTest : TypeTestHelper() {
         val fieldDirectives = result.directives
         assertEquals(1, fieldDirectives.size)
         assertEquals("deprecated", fieldDirectives.first().name)
+    }
+
+    @Test
+    fun `test changing the name of a function`() {
+        val kFunction = Happy::originalName
+        val result = builder.function(kFunction, "Query")
+        assertEquals("renamedFunction", result.name)
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/ExpediaDotCom/graphql-kotlin/issues/248

Use `@GraphQLName` to set the name of fields in the schema, not just type names