### PR TITLE
fix: use maven release plugin in update-version.sh travis script

### DIFF
--- a/.travis/update-version.sh
+++ b/.travis/update-version.sh
@@ -12,7 +12,7 @@ update_version() {
     mvn --settings .travis/settings.xml org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion="${TRAVIS_TAG}-SNAPSHOT"
 
     # Increment the patch version
-    mvn --settings .travis/settings.xml org.codehaus.mojo:versions-maven-plugin:2.7:set -DnextSnapshot=true
+    mvn --settings .travis/settings.xml release:update-versions -B
 
     # Pull the value from the pom
     NEW_VERSION=$(mvn --settings .travis/settings.xml help:evaluate -Dexpression=project.version -q -DforceStdout)


### PR DESCRIPTION
versions-maven-plugin is unable to automatically increment snapshot versions of non-standard version project (e.g. 1.0.0-RC1-SNAPSHOT).