### PR TITLE
exclude example app from release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@
 
     <modules>
         <module>graphql-kotlin-schema-generator</module>
-        <module>graphql-kotlin-spring-example</module>
     </modules>
 
     <properties>
@@ -334,12 +333,6 @@
         <!-- Activate using the release property: mvn clean install -Prelease -->
         <profile>
             <id>release</id>
-            <activation>
-                <property>
-                    <name>release</name>
-                </property>
-            </activation>
-
             <build>
                 <plugins>
                     <!-- Release to Maven central -->
@@ -400,7 +393,6 @@
             <activation>
                 <jdk>1.8</jdk>
             </activation>
-
             <build>
                 <plugins>
                     <plugin>
@@ -418,6 +410,16 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <!-- build example apps by default but exclude them from the release -->
+            <id>defaultBuild</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>graphql-kotlin-spring-example</module>
+            </modules>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Based on nexus-staging-maven-plugin it appears that plugin may not release the artifacts if last module (in our case example app) has it disabled. As I workaround I created defaultBuild profile (active by default) that includes example app but if any other profile is specified (e.g. -P release) then default one will be automatically disabled. This will allow us to release only schema generator module.