### PR TITLE
fix: directives with arguments should be created per declaration

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/SchemaGenerator.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/SchemaGenerator.kt
@@ -63,7 +63,7 @@ internal class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
             builder.additionalType(it)
         }
 
-        builder.additionalDirectives(state.directives)
+        builder.additionalDirectives(state.directives.values.toSet())
         builder.codeRegistry(codeRegistry.build())
         return config.hooks.willBuildSchema(builder).build()
     }
@@ -95,15 +95,9 @@ internal class SchemaGenerator(internal val config: SchemaGeneratorConfig) {
     internal fun scalarType(type: KType, annotatedAsID: Boolean = false) =
         scalarTypeBuilder.scalarType(type, annotatedAsID)
 
-    internal fun directives(element: KAnnotatedElement): List<GraphQLDirective> {
-        val directives = directiveTypeBuilder.directives(element)
-        state.directives.addAll(directives)
-        return directives
-    }
+    internal fun directives(element: KAnnotatedElement): List<GraphQLDirective> =
+        directiveTypeBuilder.directives(element)
 
-    internal fun fieldDirectives(field: Field): List<GraphQLDirective> {
-        val directives = directiveTypeBuilder.fieldDirectives(field)
-        state.directives.addAll(directives)
-        return directives
-    }
+    internal fun fieldDirectives(field: Field): List<GraphQLDirective> =
+        directiveTypeBuilder.fieldDirectives(field)
 }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/state/SchemaGeneratorState.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/state/SchemaGeneratorState.kt
@@ -4,21 +4,24 @@ import com.expedia.graphql.directives.DeprecatedDirective
 import graphql.Directives
 import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLType
+import java.util.concurrent.ConcurrentHashMap
 
 internal class SchemaGeneratorState(supportedPackages: List<String>) {
     val cache = TypesCache(supportedPackages)
     val additionalTypes = mutableSetOf<GraphQLType>()
-    val directives = mutableSetOf<GraphQLDirective>()
+    val directives = ConcurrentHashMap<String, GraphQLDirective>()
 
     fun getValidAdditionalTypes(): List<GraphQLType> = additionalTypes.filter { cache.doesNotContainGraphQLType(it) }
 
     init {
         // NOTE: @include and @defer query directives are added by graphql-java by default
         // adding them explicitly here to keep it consistent with missing deprecated directive
-        directives.add(Directives.IncludeDirective)
-        directives.add(Directives.SkipDirective)
+        directives[Directives.IncludeDirective.name] = Directives.IncludeDirective
+        directives[Directives.SkipDirective.name] = Directives.SkipDirective
 
         // graphql-kotlin default directives
-        directives.add(DeprecatedDirective)
+        // @deprecated directive is a built-in directive that each GraphQL server should provide bu currently it is not added by graphql-java
+        //   see https://github.com/graphql-java/graphql-java/issues/1598
+        directives[DeprecatedDirective.name] = DeprecatedDirective
     }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expedia/graphql/generator/types/TypeTestHelper.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expedia/graphql/generator/types/TypeTestHelper.kt
@@ -101,12 +101,16 @@ internal open class TypeTestHelper {
         directiveBuilder = spyk(DirectiveBuilder(generator))
         every { generator.directives(any()) } answers {
             val directives = directiveBuilder!!.directives(it.invocation.args[0] as KAnnotatedElement)
-            state.directives.addAll(directives)
+            for (directive in directives) {
+                state.directives[directive.name] = directive
+            }
             directives
         }
         every { generator.fieldDirectives(any()) } answers {
             val directives = directiveBuilder!!.fieldDirectives(it.invocation.args[0] as Field)
-            state.directives.addAll(directives)
+            for (directive in directives) {
+                state.directives[directive.name] = directive
+            }
             directives
         }
 

--- a/graphql-kotlin-spring-example/src/main/kotlin/com/expedia/graphql/sample/directives/CakeOnly.kt
+++ b/graphql-kotlin-spring-example/src/main/kotlin/com/expedia/graphql/sample/directives/CakeOnly.kt
@@ -1,6 +1,0 @@
-package com.expedia.graphql.sample.directives
-
-import com.expedia.graphql.annotations.GraphQLDirective
-
-@GraphQLDirective(description = "This validates inputted string is equal to cake")
-annotation class CakeOnly

--- a/graphql-kotlin-spring-example/src/main/kotlin/com/expedia/graphql/sample/directives/CustomDirectiveWiringFactory.kt
+++ b/graphql-kotlin-spring-example/src/main/kotlin/com/expedia/graphql/sample/directives/CustomDirectiveWiringFactory.kt
@@ -10,11 +10,11 @@ import kotlin.reflect.KClass
 class CustomDirectiveWiringFactory : KotlinDirectiveWiringFactory(manualWiring = mapOf<String, KotlinSchemaDirectiveWiring>("lowercase" to LowercaseSchemaDirectiveWiring())) {
 
     private val stringEvalDirectiveWiring = StringEvalSchemaDirectiveWiring()
-    private val caleOnlyDirectiveWiring = CakeOnlySchemaDirectiveWiring()
+    private val caleOnlyDirectiveWiring = SpecificValueOnlySchemaDirectiveWiring()
 
     override fun getSchemaDirectiveWiring(environment: KotlinSchemaDirectiveEnvironment<GraphQLDirectiveContainer>): KotlinSchemaDirectiveWiring? = when {
         environment.directive.name == getDirectiveName(StringEval::class) -> stringEvalDirectiveWiring
-        environment.directive.name == getDirectiveName(CakeOnly::class) -> caleOnlyDirectiveWiring
+        environment.directive.name == getDirectiveName(SpecificValueOnly::class) -> caleOnlyDirectiveWiring
         else -> null
     }
 }

--- a/graphql-kotlin-spring-example/src/main/kotlin/com/expedia/graphql/sample/directives/SpecificValueOnly.kt
+++ b/graphql-kotlin-spring-example/src/main/kotlin/com/expedia/graphql/sample/directives/SpecificValueOnly.kt
@@ -1,0 +1,6 @@
+package com.expedia.graphql.sample.directives
+
+import com.expedia.graphql.annotations.GraphQLDirective
+
+@GraphQLDirective(description = "This validates inputted string is equal to specified argument")
+annotation class SpecificValueOnly(val value: String)

--- a/graphql-kotlin-spring-example/src/main/kotlin/com/expedia/graphql/sample/directives/SpecificValueOnlySchemaDirectiveWiring.kt
+++ b/graphql-kotlin-spring-example/src/main/kotlin/com/expedia/graphql/sample/directives/SpecificValueOnlySchemaDirectiveWiring.kt
@@ -5,17 +5,19 @@ import com.expedia.graphql.directives.KotlinSchemaDirectiveWiring
 import graphql.schema.DataFetcher
 import graphql.schema.GraphQLFieldDefinition
 
-class CakeOnlySchemaDirectiveWiring : KotlinSchemaDirectiveWiring {
+class SpecificValueOnlySchemaDirectiveWiring : KotlinSchemaDirectiveWiring {
 
     @Throws(RuntimeException::class)
     override fun onField(environment: KotlinFieldDirectiveEnvironment): GraphQLFieldDefinition {
         val field = environment.element
         val originalDataFetcher: DataFetcher<Any> = environment.getDataFetcher()
 
+        val supportedValue = environment.directive.getArgument("value")?.value?.toString() ?: ""
+
         val cakeOnlyFetcher = DataFetcher<Any> { dataEnv ->
             val strArg: String? = dataEnv.getArgument(environment.element.arguments[0].name) as String?
-            if (!"cake".equals(other = strArg, ignoreCase = true)) {
-                throw RuntimeException("The cake is a lie!")
+            if (!supportedValue.equals(other = strArg, ignoreCase = true)) {
+                throw RuntimeException("Unsupported value, expected=$supportedValue actual=$strArg")
             }
             originalDataFetcher.get(dataEnv)
         }

--- a/graphql-kotlin-spring-example/src/main/kotlin/com/expedia/graphql/sample/query/CustomDirectiveQuery.kt
+++ b/graphql-kotlin-spring-example/src/main/kotlin/com/expedia/graphql/sample/query/CustomDirectiveQuery.kt
@@ -1,8 +1,8 @@
 package com.expedia.graphql.sample.query
 
 import com.expedia.graphql.annotations.GraphQLDescription
-import com.expedia.graphql.sample.directives.CakeOnly
 import com.expedia.graphql.sample.directives.LowercaseDirective
+import com.expedia.graphql.sample.directives.SpecificValueOnly
 import com.expedia.graphql.sample.directives.StringEval
 import org.springframework.stereotype.Component
 
@@ -13,8 +13,12 @@ class CustomDirectiveQuery : Query {
     fun justWhisper(@StringEval(default = "default string", lowerCase = true) msg: String?): String? = msg
 
     @GraphQLDescription("This will only accept 'Cake' as input")
-    @CakeOnly
+    @SpecificValueOnly("cake")
     fun onlyCake(msg: String): String = "<3"
+
+    @GraphQLDescription("This will only accept 'IceCream' as input")
+    @SpecificValueOnly("icecream")
+    fun onlyIceCream(msg: String): String = "<3"
 
     @GraphQLDescription("Returns message modified by the manually wired directive to force lowercase")
     @LowercaseDirective


### PR DESCRIPTION
Directive definitions should only be added to the schema once - while building the schema we are caching the directive definitions and add them after processing all the objects. Our current logic relies on this cache to not-rebuild the directives per each one of its declarations. Directives can have arguments which means that we have to rebuild the directive definition if they accept any arguments.