### PR TITLE
Support GraphQLDataFetcherPrefix Annotation

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/annotations/GraphQLDataFetcherPrefix.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/annotations/GraphQLDataFetcherPrefix.kt
@@ -1,0 +1,7 @@
+package com.expedia.graphql.annotations
+
+/**
+ * Set the GraphQL DataFetcher Prefix to be picked up by the schema generator.
+ */
+@Target(AnnotationTarget.CLASS)
+annotation class GraphQLDataFetcherPrefix(val value: String)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/extensions/annotationExtensions.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/extensions/annotationExtensions.kt
@@ -4,12 +4,15 @@ import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.annotations.GraphQLID
 import com.expedia.graphql.annotations.GraphQLIgnore
 import com.expedia.graphql.annotations.GraphQLName
+import com.expedia.graphql.annotations.GraphQLDataFetcherPrefix
 import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.full.findAnnotation
 
 internal fun KAnnotatedElement.getGraphQLDescription(): String? = this.findAnnotation<GraphQLDescription>()?.value
 
 internal fun KAnnotatedElement.getGraphQLName(): String? = this.findAnnotation<GraphQLName>()?.value
+
+internal fun KAnnotatedElement.getGraphQLDataFetcherPrefix(): String? = this.findAnnotation<GraphQLDataFetcherPrefix>()?.value
 
 internal fun KAnnotatedElement.getDeprecationReason(): String? = this.findAnnotation<Deprecated>()?.getReason()
 

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/types/FunctionBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/types/FunctionBuilder.kt
@@ -4,6 +4,7 @@ import com.expedia.graphql.directives.deprecatedDirectiveWithReason
 import com.expedia.graphql.exceptions.InvalidInputFieldTypeException
 import com.expedia.graphql.generator.SchemaGenerator
 import com.expedia.graphql.generator.TypeBuilder
+import com.expedia.graphql.generator.extensions.*
 import com.expedia.graphql.generator.extensions.getDeprecationReason
 import com.expedia.graphql.generator.extensions.getFunctionName
 import com.expedia.graphql.generator.extensions.getGraphQLDescription
@@ -32,7 +33,16 @@ internal class FunctionBuilder(generator: SchemaGenerator) : TypeBuilder(generat
     internal fun function(fn: KFunction<*>, parentName: String, target: Any? = null, abstract: Boolean = false): GraphQLFieldDefinition {
         val builder = GraphQLFieldDefinition.newFieldDefinition()
         val functionName = fn.getFunctionName()
-        builder.name(functionName)
+        // builder.name(functionName)
+
+        if(target!=null){
+            val prefix = target::class.getGraphQLDataFetcherPrefix()?:""
+            builder.name(prefix+functionName)
+        }else{
+            builder.name(functionName)
+        }
+
+
         builder.description(fn.getGraphQLDescription())
 
         fn.getDeprecationReason()?.let {

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expedia/graphql/generator/extensions/AnnotationExtensionsTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expedia/graphql/generator/extensions/AnnotationExtensionsTest.kt
@@ -4,6 +4,7 @@ import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.annotations.GraphQLID
 import com.expedia.graphql.annotations.GraphQLIgnore
 import com.expedia.graphql.annotations.GraphQLName
+import com.expedia.graphql.annotations.GraphQLDataFetcherPrefix
 import org.junit.jupiter.api.Test
 import kotlin.reflect.KClass
 import kotlin.reflect.full.declaredMemberProperties
@@ -24,6 +25,11 @@ internal class AnnotationExtensionsTest {
         @property:GraphQLDescription("property description")
         @property:GraphQLID
         @property:GraphQLName("newName")
+        val id: String
+    )
+
+    @GraphQLDataFetcherPrefix("example_prefix")
+    private data class WithPrefix(
         val id: String
     )
 
@@ -74,4 +80,10 @@ internal class AnnotationExtensionsTest {
     }
 
     private fun KClass<*>.findMemberProperty(name: String) = this.declaredMemberProperties.find { it.name == name }
+
+    @Test
+    fun `verify @GraphQLDataFetcherPrefix on classes`() {
+        assertEquals(expected = "example_prefix", actual = WithPrefix::class.getGraphQLDataFetcherPrefix())
+        assertNull(NoAnnotations::class.getGraphQLDataFetcherPrefix())
+    }
 }

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expedia/graphql/generator/types/QueryBuilderTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expedia/graphql/generator/types/QueryBuilderTest.kt
@@ -1,6 +1,7 @@
 package com.expedia.graphql.generator.types
 
 import com.expedia.graphql.TopLevelObject
+import com.expedia.graphql.annotations.GraphQLDataFetcherPrefix
 import com.expedia.graphql.annotations.GraphQLDescription
 import com.expedia.graphql.annotations.GraphQLIgnore
 import com.expedia.graphql.exceptions.InvalidQueryTypeException
@@ -36,6 +37,12 @@ internal class QueryBuilderTest : TypeTestHelper() {
         @GraphQLDescription("A GraphQL query method")
         fun query(value: Int) = value
     }
+
+    @GraphQLDataFetcherPrefix("example_prefix_")
+    class QueryObjectWithPrefix {
+        fun query(value: Int) = value
+    }
+
 
     class NoFunctions {
         @GraphQLIgnore
@@ -81,6 +88,15 @@ internal class QueryBuilderTest : TypeTestHelper() {
         assertEquals(expected = "TestTopLevelQuery", actual = result.name)
         assertEquals(expected = 1, actual = result.fieldDefinitions.size)
         assertEquals(expected = "query", actual = result.fieldDefinitions.first().name)
+    }
+
+    @Test
+    fun `query with valid functions with prefix`() {
+        val queries = listOf(TopLevelObject(QueryObjectWithPrefix()))
+        val result = builder.getQueryObject(queries)
+        assertEquals(expected = "TestTopLevelQuery", actual = result.name)
+        assertEquals(expected = 1, actual = result.fieldDefinitions.size)
+        assertEquals(expected = "example_prefix_query", actual = result.fieldDefinitions.first().name)
     }
 
     @Test


### PR DESCRIPTION
support add prefix to datafeter.

example:

```
@GraphQLDataFetcherPrefix("example_prefix_")
class QueryObjectWithPrefix: Query {
   fun query1(value: Int) :Int{
        ...
    }

    fun query2(value: Int) :Int{
        ...
    }

    fun query3(value: Int) :Int{
        ...
    }
}
```

The above query would produce the following GraphQL schema:
```
schema {
  query: Query
}

type Query {
  example_prefix_query1(id: Int!): Int
  example_prefix_query2(id: Int!): Int
  example_prefix_query3(id: Int!): Int
}
```
