### PR TITLE
fix: allow modifying GraphQLInterfaceType in the willAddGraphQLTypeToSchema hook

### DIFF
--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/types/InterfaceBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/types/InterfaceBuilder.kt
@@ -35,13 +35,11 @@ internal class InterfaceBuilder(generator: SchemaGenerator) : TypeBuilder(genera
             val implementations = subTypeMapper.getSubTypesOf(kClass)
             implementations.forEach { implementation ->
                 val objectType = generator.objectType(implementation.kotlin, interfaceType)
-
-                // Only update the state if the object is fully constructed and not a reference
+                // skip under construction objects
                 if (objectType !is GraphQLTypeReference) {
                     state.additionalTypes.add(objectType)
                 }
             }
-
             codeRegistry.typeResolver(interfaceType) { env: TypeResolutionEnvironment -> env.schema.getObjectType(env.getObject<Any>().javaClass.kotlin.getSimpleName()) }
             config.hooks.onRewireGraphQLType(interfaceType).safeCast()
         }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/types/ObjectBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/types/ObjectBuilder.kt
@@ -11,6 +11,7 @@ import com.expedia.graphql.generator.extensions.safeCast
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLType
+import graphql.schema.GraphQLTypeReference
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createType
 
@@ -29,7 +30,8 @@ internal class ObjectBuilder(generator: SchemaGenerator) : TypeBuilder(generator
             }
 
             if (interfaceType != null) {
-                builder.withInterface(interfaceType)
+                // invoked from the interface builder which can still be modified by the hooks
+                builder.withInterface(GraphQLTypeReference(interfaceType.name))
             } else {
                 kClass.getValidSuperclasses(config.hooks)
                     .map { objectFromReflection(it.createType(), false) }

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/types/QueryBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/types/QueryBuilder.kt
@@ -13,7 +13,6 @@ internal class QueryBuilder(generator: SchemaGenerator) : TypeBuilder(generator)
 
     @Throws(InvalidSchemaException::class)
     fun getQueryObject(queries: List<TopLevelObject>): GraphQLObjectType {
-
         if (queries.isEmpty()) {
             throw InvalidSchemaException()
         }
@@ -32,7 +31,6 @@ internal class QueryBuilder(generator: SchemaGenerator) : TypeBuilder(generator)
 
             query.kClass.getValidFunctions(config.hooks)
                 .forEach {
-                    // NEED BUILT QUERY
                     val function = generator.function(it, config.topLevelNames.query, query.obj)
                     val functionFromHook = config.hooks.didGenerateQueryType(it, function)
                     queryBuilder.field(functionFromHook)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/types/UnionBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/types/UnionBuilder.kt
@@ -4,7 +4,6 @@ import com.expedia.graphql.generator.SchemaGenerator
 import com.expedia.graphql.generator.TypeBuilder
 import com.expedia.graphql.generator.extensions.getGraphQLDescription
 import com.expedia.graphql.generator.extensions.getSimpleName
-import com.expedia.graphql.generator.state.KGraphQLType
 import com.expedia.graphql.generator.state.TypesCacheKey
 import graphql.TypeResolutionEnvironment
 import graphql.schema.GraphQLObjectType
@@ -30,15 +29,9 @@ internal class UnionBuilder(generator: SchemaGenerator) : TypeBuilder(generator)
                 val objectType = state.cache.get(TypesCacheKey(it.kotlin.createType(), false))
                     ?: generator.objectType(it.kotlin)
 
-                val key = TypesCacheKey(it.kotlin.createType(), false)
-
                 when (objectType) {
                     is GraphQLTypeReference -> builder.possibleType(objectType)
                     is GraphQLObjectType -> builder.possibleType(objectType)
-                }
-
-                if (state.cache.doesNotContain(it.kotlin)) {
-                    state.cache.put(key, KGraphQLType(it.kotlin, objectType))
                 }
             }
             val unionType = builder.build()

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expedia/graphql/hooks/SchemaGeneratorHooksTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expedia/graphql/hooks/SchemaGeneratorHooksTest.kt
@@ -113,7 +113,8 @@ class SchemaGeneratorHooksTest {
                 hookCalled = true
                 return when {
                     generatedType is GraphQLObjectType && generatedType.name == "SomeData" -> GraphQLObjectType.newObject(generatedType).description("My custom description").build()
-                    generatedType is GraphQLInterfaceType -> GraphQLInterfaceType.newInterface(generatedType).description("My custom interface description").build()
+                    generatedType is GraphQLInterfaceType && generatedType.name == "RandomData" ->
+                        GraphQLInterfaceType.newInterface(generatedType).description("My custom interface description").build()
                     else -> generatedType
                 }
             }
@@ -129,6 +130,10 @@ class SchemaGeneratorHooksTest {
         val type = schema.getObjectType("SomeData")
         assertNotNull(type)
         assertEquals(expected = "My custom description", actual = type.description)
+
+        val interfaceType = schema.getType("RandomData") as? GraphQLInterfaceType
+        assertNotNull(interfaceType)
+        assertEquals(expected = "My custom interface description", actual = interfaceType.description)
     }
 
     @Test


### PR DESCRIPTION
InterfaceBuilder attempts to create all the implementing `GraphQLObjectType`s after building an interface but before executing the `willAddGraphQLTypeToSchema` hook. This means that if we attempt to update the interface in that hook there could be some objects implementing that interface and referencing the old one. Since graphql-java schema objects don't implement hashcode we end up with type conflict of two interfaces being defined in the schema.

Fix is to use `GraphQLTypeReference` when referencing `GraphQLInterfaceType` from the `GraphQLObjectType` builder. Reference is just by name and they are resolved as the last step of building a schema. This allows us to modify the interface in the hook.

Resolves: https://github.com/ExpediaDotCom/graphql-kotlin/issues/281