### PR TITLE
chore: exclude the example app from code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+#
+# codecov.io Configuration
+# See the docs here: https://docs.codecov.io/docs/codecov-yaml
+#
+
+# Ingore the example app from coverage reports
+ignore:
+  - "graphql-kotlin-spring-example/**/*"


### PR DESCRIPTION
Instead of deleting the tests, we can just exclude this project from the reports

This is the previous PR https://github.com/ExpediaDotCom/graphql-kotlin/pull/290