### PR TITLE
Changes to sdl field of _service object to make it compliant with the…

### DIFF
--- a/graphql-kotlin-federation/src/main/kotlin/com/expedia/graphql/federation/FederatedSchemaGeneratorHooks.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expedia/graphql/federation/FederatedSchemaGeneratorHooks.kt
@@ -59,9 +59,11 @@ open class FederatedSchemaGeneratorHooks(private val federatedTypeRegistry: Fede
             federatedQuery.field(entityField)
 
             // SDL returned by _service query should not contain directives or new scalars
-            val sdl = originalSchema.print()
+            val sdl = originalSchema
+                .print(includeDefaultSchemaDefinition = false)
                 .replace(directiveRegex, "")
                 .replace(scalarRegex, "")
+                .replace("type Query", "type Query @extends")
                 .trim()
             federatedCodeRegistry.dataFetcher(FieldCoordinates.coordinates(originalQuery.name, SERVICE_FIELD_DEFINITION.name), DataFetcher { _Service(sdl) })
             federatedCodeRegistry.dataFetcher(FieldCoordinates.coordinates(originalQuery.name, entityField.name), DataFetcher {

--- a/graphql-kotlin-federation/src/main/kotlin/com/expedia/graphql/federation/FederatedSchemaGeneratorHooks.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expedia/graphql/federation/FederatedSchemaGeneratorHooks.kt
@@ -25,6 +25,7 @@ import kotlin.reflect.full.findAnnotation
 open class FederatedSchemaGeneratorHooks(private val federatedTypeRegistry: FederatedTypeRegistry) : SchemaGeneratorHooks {
     private val directiveRegex = "(^#.+$[\\r\\n])?^directive @\\w+.+$[\\r\\n]*".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
     private val scalarRegex = "(^#.+$[\\r\\n])?^scalar (_FieldSet|_Any)$[\\r\\n]*".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
+    private val emptyQuery = "^type Query \\{$\\s+^\\}$\\s+".toRegex(setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
     private val validator = FederatedSchemaValidator()
 
     override fun willGenerateGraphQLType(type: KType): GraphQLType? = when (type.classifier) {
@@ -58,12 +59,16 @@ open class FederatedSchemaGeneratorHooks(private val federatedTypeRegistry: Fede
             val entityField = generateEntityFieldDefinition(entityTypeNames)
             federatedQuery.field(entityField)
 
-            // SDL returned by _service query should not contain directives or new scalars
-            val sdl = originalSchema
-                .print(includeDefaultSchemaDefinition = false)
+            // SDL returned by _service query should NOT contain
+            // - default schema definition
+            // - empty Query type
+            // - directives
+            // - new scalars
+            val sdl = originalSchema.print(includeDefaultSchemaDefinition = false)
                 .replace(directiveRegex, "")
                 .replace(scalarRegex, "")
-                .replace("type Query", "type Query @extends")
+                .replace(emptyQuery, "")
+                .replace("type ${originalQuery.name}", "type ${originalQuery.name} @extends")
                 .trim()
             federatedCodeRegistry.dataFetcher(FieldCoordinates.coordinates(originalQuery.name, SERVICE_FIELD_DEFINITION.name), DataFetcher { _Service(sdl) })
             federatedCodeRegistry.dataFetcher(FieldCoordinates.coordinates(originalQuery.name, entityField.name), DataFetcher {

--- a/graphql-kotlin-federation/src/test/kotlin/com/expedia/graphql/federation/execution/ServiceQueryResolverTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expedia/graphql/federation/execution/ServiceQueryResolverTest.kt
@@ -25,9 +25,6 @@ type Book implements Product @extends @key(fields : "id") {
   weight: Float! @external
 }
 
-type Query @extends {
-}
-
 type Review {
   body: String!
   id: String!

--- a/graphql-kotlin-federation/src/test/kotlin/com/expedia/graphql/federation/execution/ServiceQueryResolverTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expedia/graphql/federation/execution/ServiceQueryResolverTest.kt
@@ -11,10 +11,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 // SDL is returned without _entity and _service queries
-const val FEDERATED_SERVICE_SDL = """schema {
-  query: Query
-}
-
+const val FEDERATED_SERVICE_SDL = """
 interface Product @extends @key(fields : "id") {
   id: String! @external
   reviews: [Review!]!
@@ -28,7 +25,7 @@ type Book implements Product @extends @key(fields : "id") {
   weight: Float! @external
 }
 
-type Query {
+type Query @extends {
 }
 
 type Review {
@@ -69,6 +66,6 @@ class ServiceQueryResolverTest {
         val queryResult = data["_service"] as? Map<*, *>
         assertNotNull(queryResult)
         val sdl = queryResult["sdl"] as? String
-        assertEquals(FEDERATED_SERVICE_SDL, sdl)
+        assertEquals(FEDERATED_SERVICE_SDL.trim(), sdl)
     }
 }


### PR DESCRIPTION
… federation specification

- if the Query type is present, it should have the @extends directive, since it extends the query type
- the default schema definition should not be includeded in the sdl. This causes problems for example with the @apollo/gateway, because if the default schema definition is present, no queries are picked up from the federated schema.