### PR TITLE
Spring boot example was missing the plugin to work correctly

### DIFF
--- a/graphql-kotlin-spring-example/pom.xml
+++ b/graphql-kotlin-spring-example/pom.xml
@@ -38,6 +38,12 @@
         <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
         <plugins>
             <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+            </plugin>
+
+            <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <executions>


### PR DESCRIPTION
Update the example application to include the spring maven plugin

This allows us to use
```
mvn spring-boot:run
```

instead of

```
mvn org.springframework.boot:spring-boot-maven-plugin:run
```