### PR TITLE
Fix wrapped federation

### DIFF
--- a/graphql-kotlin-federation/src/main/kotlin/com/expedia/graphql/federation/execution/FederatedTypeRegistry.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expedia/graphql/federation/execution/FederatedTypeRegistry.kt
@@ -3,7 +3,7 @@ package com.expedia.graphql.federation.execution
 /**
  * Simple registry that holds mapping of all registered federated GraphQL types and their corresponding resolvers.
  */
-class FederatedTypeRegistry(private val federatedTypeResolvers: Map<String, FederatedTypeResolver<*>>) {
+class FederatedTypeRegistry(private val federatedTypeResolvers: Map<String, FederatedTypeResolver<*>> = emptyMap()) {
 
     /**
      * Retrieve target federated resolver for the specified GraphQL type.

--- a/graphql-kotlin-federation/src/test/kotlin/com/expedia/graphql/federation/FederatedSchemaGeneratorTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expedia/graphql/federation/FederatedSchemaGeneratorTest.kt
@@ -85,7 +85,7 @@ class FederatedSchemaGeneratorTest {
     fun `verify can generate federated schema`() {
         val config = FederatedSchemaGeneratorConfig(
             supportedPackages = listOf("test.data.queries.federated"),
-            hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry(emptyMap()))
+            hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry())
         )
 
         val schema = toFederatedSchema(config)
@@ -118,7 +118,7 @@ class FederatedSchemaGeneratorTest {
 
         val config = FederatedSchemaGeneratorConfig(
             supportedPackages = listOf("test.data.queries.simple"),
-            hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry(emptyMap()))
+            hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry())
         )
 
         val schema = toFederatedSchema(config, listOf(TopLevelObject(SimpleQuery())))

--- a/graphql-kotlin-federation/src/test/kotlin/com/expedia/graphql/federation/execution/ServiceQueryResolverTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expedia/graphql/federation/execution/ServiceQueryResolverTest.kt
@@ -40,7 +40,7 @@ class ServiceQueryResolverTest {
     fun `verify can retrieve SDL using _service query`() {
         val config = FederatedSchemaGeneratorConfig(
             supportedPackages = listOf("test.data.queries.federated"),
-            hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry(emptyMap()))
+            hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry())
         )
 
         val schema = toFederatedSchema(config)

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/TypeBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/TypeBuilder.kt
@@ -30,7 +30,7 @@ internal open class TypeBuilder constructor(protected val generator: SchemaGener
             ?: objectFromReflection(type, inputType)
 
         // Do not call the hook on GraphQLTypeReference as we have not generated the type yet
-        val unwrappedType = GraphQLTypeUtil.unwrapNonNull(graphQLType)
+        val unwrappedType = GraphQLTypeUtil.unwrapType(graphQLType).lastElement()
         if (unwrappedType !is GraphQLTypeReference) {
             val typeWithNullability = graphQLType.wrapInNonNull(type)
             return config.hooks.didGenerateGraphQLType(type, typeWithNullability)

--- a/graphql-kotlin-spring-example/pom.xml
+++ b/graphql-kotlin-spring-example/pom.xml
@@ -27,6 +27,11 @@
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.expedia</groupId>
+            <artifactId>graphql-kotlin-federation</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
             <version>${spring-boot.version}</version>

--- a/graphql-kotlin-spring-example/src/main/kotlin/com/expedia/graphql/sample/extension/CustomSchemaGeneratorHooks.kt
+++ b/graphql-kotlin-spring-example/src/main/kotlin/com/expedia/graphql/sample/extension/CustomSchemaGeneratorHooks.kt
@@ -2,7 +2,8 @@ package com.expedia.graphql.sample.extension
 
 import com.expedia.graphql.directives.KotlinDirectiveWiringFactory
 import com.expedia.graphql.execution.DataFetcherExecutionPredicate
-import com.expedia.graphql.hooks.SchemaGeneratorHooks
+import com.expedia.graphql.federation.FederatedSchemaGeneratorHooks
+import com.expedia.graphql.federation.execution.FederatedTypeRegistry
 import com.expedia.graphql.sample.validation.DataFetcherExecutionValidator
 import graphql.language.StringValue
 import graphql.schema.Coercing
@@ -15,7 +16,7 @@ import kotlin.reflect.KType
 /**
  * Schema generator hook that adds additional scalar types.
  */
-class CustomSchemaGeneratorHooks(validator: Validator, override val wiringFactory: KotlinDirectiveWiringFactory) : SchemaGeneratorHooks {
+class CustomSchemaGeneratorHooks(validator: Validator, override val wiringFactory: KotlinDirectiveWiringFactory, federatedTypeRegistry: FederatedTypeRegistry) : FederatedSchemaGeneratorHooks(federatedTypeRegistry) {
 
     /**
      * Register additional GraphQL scalar types.

--- a/graphql-kotlin-spring-example/src/main/kotlin/com/expedia/graphql/sample/query/NestedQueries.kt
+++ b/graphql-kotlin-spring-example/src/main/kotlin/com/expedia/graphql/sample/query/NestedQueries.kt
@@ -67,3 +67,13 @@ class CoffeeBean {
         return "Hot Coffee, Bean choice: $beanChoice, size: $size"
     }
 }
+
+@Component
+class SimpleNestedObjectQuery : Query {
+    fun getSimpleNestedObject() = SelfReferenceObject()
+}
+
+class SelfReferenceObject {
+    val description = "SelfReferenceObject"
+    fun nextObject() =SelfReferenceObject()
+}

--- a/graphql-kotlin-spring-example/src/test/kotlin/com/expedia/graphql/sample/extension/CustomSchemaGeneratorHooksTest.kt
+++ b/graphql-kotlin-spring-example/src/test/kotlin/com/expedia/graphql/sample/extension/CustomSchemaGeneratorHooksTest.kt
@@ -1,6 +1,7 @@
 package com.expedia.graphql.sample.extension
 
 import com.expedia.graphql.directives.KotlinDirectiveWiringFactory
+import com.expedia.graphql.federation.execution.FederatedTypeRegistry
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import java.util.UUID
@@ -18,7 +19,7 @@ class CustomSchemaGeneratorHooksTest {
     fun `UUID returns a string scalar`() {
         val validator: Validator = mockk()
         val wiringFactory: KotlinDirectiveWiringFactory = mockk()
-        val hooks = CustomSchemaGeneratorHooks(validator, wiringFactory)
+        val hooks = CustomSchemaGeneratorHooks(validator, wiringFactory, FederatedTypeRegistry())
 
         val result = hooks.willGenerateGraphQLType(UUID::class.createType())
         assertNotNull(result)
@@ -29,7 +30,7 @@ class CustomSchemaGeneratorHooksTest {
     fun `Non valid type returns null`() {
         val validator: Validator = mockk()
         val wiringFactory: KotlinDirectiveWiringFactory = mockk()
-        val hooks = CustomSchemaGeneratorHooks(validator, wiringFactory)
+        val hooks = CustomSchemaGeneratorHooks(validator, wiringFactory, FederatedTypeRegistry())
 
         val result = hooks.willGenerateGraphQLType(NonScalar::class.createType())
         assertNull(result)


### PR DESCRIPTION
Fixes https://github.com/ExpediaDotCom/graphql-kotlin/issues/310

While I don't think it is possible to have an input type extended we should still be able to have nested types that are not part of the federated entities be generated properly. This can happen when there are lists of nullalbes or double wrapped elements

![Screen Shot 2019-08-30 at 5 09 10 PM](https://user-images.githubusercontent.com/2446877/64056570-047f1800-cb49-11e9-9f5c-df195f559a12.png)
