### PR TITLE
Fix nested federation

### DIFF
--- a/examples/federation/base-app/src/main/kotlin/com/expedia/graphql/sample/Application.kt
+++ b/examples/federation/base-app/src/main/kotlin/com/expedia/graphql/sample/Application.kt
@@ -29,7 +29,7 @@ class Application {
     private val logger = LoggerFactory.getLogger(Application::class.java)
 
     @Bean
-    fun hooks() = FederatedSchemaGeneratorHooks(FederatedTypeRegistry(emptyMap()))
+    fun hooks() = FederatedSchemaGeneratorHooks(FederatedTypeRegistry())
 
     @Bean
     fun dataFetcherFactoryProvider(springDataFetcherFactory: SpringDataFetcherFactory, hooks: SchemaGeneratorHooks) =

--- a/examples/federation/base-app/src/main/kotlin/com/expedia/graphql/sample/query/NestedQuery.kt
+++ b/examples/federation/base-app/src/main/kotlin/com/expedia/graphql/sample/query/NestedQuery.kt
@@ -1,0 +1,15 @@
+package com.expedia.graphql.sample.query
+
+import org.springframework.stereotype.Component
+import kotlin.random.Random
+
+@Component
+class NestedQuery : Query {
+    fun getSimpleNestedObject(): List<SelfReferenceObject?> = listOf(SelfReferenceObject())
+}
+
+class SelfReferenceObject {
+    val description: String? = "SelfReferenceObject"
+    val id = Random.nextInt()
+    fun nextObject(): List<SelfReferenceObject?> = listOf(SelfReferenceObject())
+}

--- a/examples/spring/pom.xml
+++ b/examples/spring/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>..</relativePath>
     </parent>
 
-    <artifactId>spring</artifactId>
+    <artifactId>spring-example</artifactId>
     <description>Example SpringBoot app using graphql-kotlin</description>
     <url>https://github.com/ExpediaDotCom/graphql-kotlin</url>
     <packaging>jar</packaging>

--- a/examples/spring/pom.xml
+++ b/examples/spring/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>..</relativePath>
     </parent>
 
-    <artifactId>spring-example</artifactId>
+    <artifactId>spring</artifactId>
     <description>Example SpringBoot app using graphql-kotlin</description>
     <url>https://github.com/ExpediaDotCom/graphql-kotlin</url>
     <packaging>jar</packaging>

--- a/graphql-kotlin-federation/src/main/kotlin/com/expedia/graphql/federation/execution/FederatedTypeRegistry.kt
+++ b/graphql-kotlin-federation/src/main/kotlin/com/expedia/graphql/federation/execution/FederatedTypeRegistry.kt
@@ -3,7 +3,7 @@ package com.expedia.graphql.federation.execution
 /**
  * Simple registry that holds mapping of all registered federated GraphQL types and their corresponding resolvers.
  */
-class FederatedTypeRegistry(private val federatedTypeResolvers: Map<String, FederatedTypeResolver<*>>) {
+class FederatedTypeRegistry(private val federatedTypeResolvers: Map<String, FederatedTypeResolver<*>> = emptyMap()) {
 
     /**
      * Retrieve target federated resolver for the specified GraphQL type.

--- a/graphql-kotlin-federation/src/test/kotlin/com/expedia/graphql/federation/execution/EntityQueryResolverTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expedia/graphql/federation/execution/EntityQueryResolverTest.kt
@@ -43,7 +43,7 @@ class EntityQueryResolverTest {
 
     @Test
     fun `verify federated entity resolver returns GraphQLError if __typename cannot be resolved`() {
-        val resolver = EntityResolver(FederatedTypeRegistry(emptyMap()))
+        val resolver = EntityResolver(FederatedTypeRegistry())
         val representations = listOf(mapOf<String, Any>("__typename" to "User", "userId" to 123, "name" to "testName"))
         val env = mockk<DataFetchingEnvironment> {
             every { getArgument<Any>(any()) } returns representations

--- a/graphql-kotlin-federation/src/test/kotlin/com/expedia/graphql/federation/execution/ServiceQueryResolverTest.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/com/expedia/graphql/federation/execution/ServiceQueryResolverTest.kt
@@ -40,7 +40,7 @@ class ServiceQueryResolverTest {
     fun `verify can retrieve SDL using _service query`() {
         val config = FederatedSchemaGeneratorConfig(
             supportedPackages = listOf("test.data.queries.federated"),
-            hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry(emptyMap()))
+            hooks = FederatedSchemaGeneratorHooks(FederatedTypeRegistry())
         )
 
         val schema = toFederatedSchema(config)

--- a/graphql-kotlin-federation/src/test/kotlin/test/data/queries/simple/NestedQuery.kt
+++ b/graphql-kotlin-federation/src/test/kotlin/test/data/queries/simple/NestedQuery.kt
@@ -1,0 +1,13 @@
+package test.data.queries.simple
+
+import kotlin.random.Random
+
+class NestedQuery {
+    fun getSimpleNestedObject(): List<SelfReferenceObject?> = listOf(SelfReferenceObject())
+}
+
+class SelfReferenceObject {
+    val description: String? = "SelfReferenceObject"
+    val id = Random.nextInt()
+    fun nextObject(): List<SelfReferenceObject?> = listOf(SelfReferenceObject())
+}

--- a/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/TypeBuilder.kt
+++ b/graphql-kotlin-schema-generator/src/main/kotlin/com/expedia/graphql/generator/TypeBuilder.kt
@@ -30,7 +30,7 @@ internal open class TypeBuilder constructor(protected val generator: SchemaGener
             ?: objectFromReflection(type, inputType)
 
         // Do not call the hook on GraphQLTypeReference as we have not generated the type yet
-        val unwrappedType = GraphQLTypeUtil.unwrapNonNull(graphQLType)
+        val unwrappedType = GraphQLTypeUtil.unwrapType(graphQLType).lastElement()
         if (unwrappedType !is GraphQLTypeReference) {
             val typeWithNullability = graphQLType.wrapInNonNull(type)
             return config.hooks.didGenerateGraphQLType(type, typeWithNullability)

--- a/graphql-kotlin-schema-generator/src/test/kotlin/com/expedia/graphql/test/integration/NodeGraphTest.kt
+++ b/graphql-kotlin-schema-generator/src/test/kotlin/com/expedia/graphql/test/integration/NodeGraphTest.kt
@@ -36,7 +36,7 @@ data class Node(
     val id: Int,
     val value: String,
     val parent: Node? = null,
-    var children: List<Node> = emptyList()
+    var children: List<Node?> = emptyList()
 )
 
 class NodeQuery {


### PR DESCRIPTION
Fixes https://github.com/ExpediaDotCom/graphql-kotlin/issues/310

While I don't think it is possible to have an input type extended we should still be able to have nested types that are not part of the federated entities be generated properly. This can happen when there are lists of nullalbes or double wrapped elements